### PR TITLE
Adding promptsploit

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://twitte
 * [Adversarial Robustness Toolkit](https://research.ibm.com/projects/adversarial-robustness-toolbox) - _ART focuses on the threats of Evasion (change the model behavior with input modifications), Poisoning (control a model with training data modifications), Extraction (steal a model through queries) and Inference (attack the privacy of the training data)_
 * [cleverhans](https://github.com/cleverhans-lab/cleverhans) - _An adversarial example library for constructing attacks, building defenses, and benchmarking both_
 * [foolbox](https://github.com/bethgelab/foolbox) - _A Python toolbox to create adversarial examples that fool neural networks in PyTorch, TensorFlow, and JAX_
-* [promptsploit] (https://github.com/slrbl/promptsploit-llm-vulnerability-scanner) - _Scan your LLM application against OWASP TOP for LLM vulnerabilities and get a clear report_
+* [promptsploit](https://github.com/slrbl/promptsploit-llm-vulnerability-scanner) - _Scan your LLM application against OWASP TOP for LLM vulnerabilities and get a clear report_
 
 ### LLM
 * [garak](https://github.com/leondz/garak/) - _security probing tool for LLMs_

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://twitte
 * [Adversarial Robustness Toolkit](https://research.ibm.com/projects/adversarial-robustness-toolbox) - _ART focuses on the threats of Evasion (change the model behavior with input modifications), Poisoning (control a model with training data modifications), Extraction (steal a model through queries) and Inference (attack the privacy of the training data)_
 * [cleverhans](https://github.com/cleverhans-lab/cleverhans) - _An adversarial example library for constructing attacks, building defenses, and benchmarking both_
 * [foolbox](https://github.com/bethgelab/foolbox) - _A Python toolbox to create adversarial examples that fool neural networks in PyTorch, TensorFlow, and JAX_
+* [promptsploit] (https://github.com/slrbl/promptsploit-llm-vulnerability-scanner) - _Scan your LLM application against OWASP TOP for LLM vulnerabilities and get a clear report_
 
 ### LLM
 * [garak](https://github.com/leondz/garak/) - _security probing tool for LLMs_


### PR DESCRIPTION
promptsploit is a tool for assessing the security and quality of LLM applications. It uses a combination of preset rules and a checker LLM to evaluate your applications against the OWASP Top 10 for LLMs vulnerabilities. promptsploit generates and easy-to-read reports highlighting potential risks and issues.

