### PR TITLE
Add dstack to Privacy and confidentiality section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,5 +126,6 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://twitte
 * [SyMPC](https://github.com/OpenMined/SyMPC) - _A Secure Multiparty Computation companion library for Syft_
 * [PyVertical](https://github.com/OpenMined/PyVertical) - _Privacy Preserving Vertical Federated Learning_
 * [Cloaked AI](https://ironcorelabs.com/products/cloaked-ai/) - _Open source property-preserving encryption for vector embeddings_
+* [dstack](https://github.com/Dstack-TEE/dstack) - _Open-source confidential AI framework for secure ML/LLM deployment with hardware-enforced isolation and data privacy_
 * [PrivacyRaven](https://github.com/trailofbits/PrivacyRaven) - _privacy testing library for deep learning systems_
 


### PR DESCRIPTION
This PR adds dstack to the Privacy and confidentiality section under Defensive Tools and Frameworks.

dstack is an open-source confidential AI framework for secure ML/LLM deployment with hardware-enforced isolation and data privacy using Intel TDX and NVIDIA Confidential Computing.

Perfect fit for the privacy and confidentiality tools alongside TenSEAL, SyMPC, and other privacy-preserving frameworks.