### PR TITLE
Adding Before The Commit Podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://twitte
 ### Podcasts
 * [MLSecOps podcast](https://mlsecops.com/podcast)
 * [AI Security Podcast](https://www.aisecuritypodcast.com/)
+* [Before The Commit Podcast](https://www.beforethecommit.com/)
 
 ## Governance
 


### PR DESCRIPTION
Before The Commit is a podcast focused on AI LLM trends and security methodologies and threat models.  https://www.beforethecommit.com/