### PR TITLE
add AATMF

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [AI Incident Database](https://incidentdatabase.ai/)
 * [NIST AI Glossary](https://airc.nist.gov/glossary/)
 * [The Arcanum Prompt Injection Taxonomy ](https://github.com/Arcanum-Sec/arc_pi_taxonomy)
-* [CSA LLM Threats Taxonomy](https://cloudsecurityalliance.org/artifacts/csa-large-language-model-llm-threats-taxonomy)
+* [CSA LLM Threats Taxonomy](https://cloudsecurityalliance.org/artifacts/csa-large-language-model-llm-threats-taxonomy)- [
+* AATMF](https://snailsploit.com/frameworks/aatmf/) - Comprehensive adversarial AI TTPs with 40+ techniques.
+
 
 ### Other material
 * [OWASP LLM Applications Cybersecurity and Governance Checklist](https://genai.owasp.org/resource/llm-applications-cybersecurity-and-governance-checklist-english/)


### PR DESCRIPTION
## Summary
Adding the AATMF (Adversarial AI Threat Modeling Framework) to the Threat Modeling section.

## Why This Addition?
- AATMF is a comprehensive open-source framework with 14 tactics and 40+ techniques for AI red teaming
- Created by Kai Aizen (Multiple CVE holder / GenAI/LLM Researcher worked with fortune 500)
- Featured in Hakin9 Magazine and PenTest Magazine
- Complements existing frameworks like MITRE ATLAS by providing a red team-specific perspective
- Active development with most recent update January 2026
- Considered for OWASP GenAI 2026 

## Links
- Framework: https://snailsploit.com/frameworks/aatmf/
- GitHub Repo: https://github.com/SnailSploit/Aversarial-AI-Threat-Modeling-Framwork
- Research: https://snailsploit.com/ai-security/

## Checklist
- [x] Added to appropriate section (Threat Modeling)
- [x] Alphabetically ordered
- [x] Link is working
- [x] Description is concise and accurate
