### PR TITLE
Add guardian-cli to AI for offensive cyber section

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [blackice](https://github.com/databricks/containers/tree/master/ubuntu/blackice) - _BlackIce is an open-source containerized toolkit designed for red teaming AI models, including Large Language Models (LLMs) and classical machine learning (ML) models. Inspired by the convenience and standardization of Kali Linux in traditional penetration testing, BlackIce simplifies AI security assessments by providing a reproducible container image preconfigured with specialized evaluation tools._
 
 ### AI for offensive cyber
+* [guardian-cli](https://github.com/zakirkun/guardian-cli) - _AI-Powered Security Testing & Vulnerability Scanner. Guardian CLI is an intelligent security testing tool that leverages AI to automate penetration testing, vulnerability assessment, and security auditing._
 * [AI-Red-Teaming-Playground-Labs](https://github.com/microsoft/AI-Red-Teaming-Playground-Labs) - _AI Red Teaming playground labs to run AI Red Teaming trainings including infrastructure._
 * [HackGPT](https://github.com/NoDataFound/hackGPT) - _A tool using ChatGPT for hacking_
 * [mcp-for-security](https://github.com/cyproxio/mcp-for-security) - _A collection of Model Context Protocol servers for popular security tools like SQLMap, FFUF, NMAP, Masscan and more. Integrate security testing and penetration testing into AI workflows._


### PR DESCRIPTION
Adds [guardian-cli](https://github.com/zakirkun/guardian-cli) - AI-Powered Security Testing & Vulnerability Scanner to the AI for offensive cyber section.

**What it does:**
- AI-powered penetration testing automation
- Vulnerability assessment
- Security auditing

**Category:** AI for offensive cyber