### PR TITLE
Add PromptTrace to Technical material & labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [OWASP WrongSecrets LLM exercise](https://wrongsecrets.herokuapp.com/challenge/32)
 * [vulnerable-mcp-servers-lab](https://github.com/appsecco/vulnerable-mcp-servers-lab) - _A collection of servers which are deliberately vulnerable to learn Pentesting MCP Servers._
 * [FinBot Agentic AI Capture The Flag (CTF) Application](https://genai.owasp.org/resource/finbot-agentic-ai-capture-the-flag-ctf-application/) - _FinBot is an Agentic Security Capture The Flag (CTF) interactive platform that simulates real-world vulnerabilities in agentic AI systems using a simulated Financial Services-focused application._
+* [PromptTrace](https://prompttrace.airedlab.com/) - _Interactive AI security training platform with 7 attack labs and a 15-level Gauntlet. Practice prompt injection, jailbreaking, tool abuse, and defense bypass against real LLMs with a Context Trace that visualizes system prompts, defense layers, and tool calls in real time._
 
 ### Podcasts
 * [MLSecOps podcast](https://mlsecops.com/podcast)


### PR DESCRIPTION
## Summary
- Adds [PromptTrace](https://prompttrace.airedlab.com/) to the **Technical material & labs** section
- Interactive AI security training platform with 7 attack labs and a 15-level Gauntlet
- Features real-time Context Trace visualization of system prompts, defense layers, and tool calls
- Covers prompt injection, jailbreaking, tool abuse, and defense bypass against real LLMs (not regex-based)
- Includes 8 learning modules covering OWASP LLM Top 10 topics
- Free online access, no setup required

## Why it fits
PromptTrace is a hands-on training environment for AI/LLM security — similar in scope to the other labs listed (FinBot CTF, OWASP WrongSecrets, etc.) but focused on prompt injection, defense bypass, and tool enumeration with real LLM backends.