### PR TITLE
Add ATR (Agent Threat Rules) to MCP Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [mcp-guardian](https://github.com/eqtylab/mcp-guardian/) - _MCP Guardian manages your LLM assistant's access to MCP servers, handing you realtime control of your LLM's activity._
 * [MCP Audit VSCode Extension](https://github.com/Agentity-com/mcp-audit-extension) - _Audit and log all GitHub Copilot MCP tool calls in VSCode centrally with ease._
 * [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - _A security scanning tool for MCP servers_
+* [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - _Open-source detection rules for AI agent threats. 108 regex rules covering prompt injection, tool poisoning, credential exfiltration across 9 categories. Used by Cisco AI Defense. MIT licensed._
 
 ### Model & Artifact Scanning
 * [modelscan](https://github.com/protectai/modelscan) - _ModelScan is an open source project from Protect AI that scans models to determine if they contain unsafe code._


### PR DESCRIPTION
108 open-source detection rules for AI agent threats. Shipped in Cisco AI Defense ([PR #79](https://github.com/cisco-ai-defense/skill-scanner/pull/79)). 53K+ skills scanned, 0% FP. [agentthreatrule.org](https://agentthreatrule.org)