### PR TITLE
Add GTK Cyber AI Training Dojo to Courses, Labs & CTFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [AI-Red-Teaming-Playground-Labs](https://github.com/microsoft/AI-Red-Teaming-Playground-Labs) - _AI Red Teaming playground labs to run AI Red Teaming trainings including infrastructure._
 * [Damn Vulnerable LLM Agent](https://github.com/ReversecLabs/damn-vulnerable-llm-agent) - _Intentionally vulnerable LLM agent for learning about prompt injection, tool misuse, and agent security_
 * [AI GOAT](https://github.com/dhammon/ai-goat) - _Damn Vulnerable LLM application with 10 challenges covering OWASP LLM Top 10 risks. Educational CTF-style lab._
+* [GTK Cyber AI Training Dojo](https://gtkcyber.com/lp/ai-training-dojo) - _Free AI security training platform with 14 prompt injection challenges, RAG poisoning labs, and MCP exploitation exercises. CTF-style scoring with leaderboard._
 
 ### Podcasts
 * [MLSecOps podcast](https://mlsecops.com/podcast)


### PR DESCRIPTION
Added GTK Cyber AI Training Dojo to Courses, Labs & CTFs. Free interactive AI security training platform with prompt injection challenges, RAG poisoning labs, and encoding bypass exercises.