### PR TITLE
Add mythos-agent to AI-Assisted Defensive Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [ThreatForest](https://github.com/aws-samples/sample-agentic-attack-tree-generator) - _Agentic threat modeling platform built on Strands framework. Autonomously generates attack trees from repositories, maps attack steps to MITRE ATT&CK techniques, and produces actionable mitigation recommendations._
 * [claude-grc-plugin](https://github.com/mlunato47/claude-grc-plugin) - _Claude Code plugin that turns Claude into a senior GRC analyst. 72+ reference files covering 15 frameworks (NIST 800-53, FedRAMP, ISO 27001, SOC 2, etc.), 24 slash commands, and deep domain knowledge for federal and commercial compliance work._
 * [Vigil SOC](https://github.com/Vigil-SOC/vigil) - _A comprehensive open-source security operations platform for AI agents, enabling real-time monitoring, threat detection, and incident response for AI-powered environments._
+* [mythos-agent](https://github.com/mythos-agent/mythos-agent) - _Open-source AI security agent combining SAST (43 scanner categories), DAST (fuzzer and PoC generator), and a policy-as-code engine (SOC2/HIPAA/PCI/GDPR/OWASP) with an MCP server for IDE and coding-agent integration._
 
 ### Privacy & Confidential Computing
 * [Python Differential Privacy Library](https://github.com/OpenMined/PyDP)


### PR DESCRIPTION
## What
[mythos-agent](https://github.com/mythos-agent/mythos-agent) — open-source AI security agent combining SAST (43 scanner categories), DAST (fuzzer + PoC generator), and a policy-as-code engine (SOC2/HIPAA/PCI/GDPR/OWASP), exposed through a CLI and an MCP server.

## Why it fits AI-Assisted Defensive Security
Sits alongside Claude Code Security Review and Vigil SOC — AI-assisted tooling aimed at defenders. Unlike those, mythos-agent bundles static + dynamic + policy scanning under one CLI and exposes it over MCP so coding assistants (Claude Code, Cursor, etc.) can invoke security analysis in-editor.

## Verification
- Repo: https://github.com/mythos-agent/mythos-agent
- License: MIT
- Latest release: v4.0.0 (2026-04-21)
- Actively maintained: commits in the last week
- 351 tests passing in CI