### PR TITLE
Add tool-output-mimicry to Agentic AI & MCP Attack Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [mcp-injection-experiments](https://github.com/invariantlabs-ai/mcp-injection-experiments) - _Code snippets to reproduce MCP tool poisoning attacks._
 * [AI-Infra-Guard](https://github.com/Tencent/AI-Infra-Guard/) - _A comprehensive, intelligent, and easy-to-use AI Red Teaming platform developed by Tencent Zhuque Lab. Integrates modules for Infra Scan, MCP Scan, and Jailbreak Evaluation, providing a one-click web UI, REST APIs, and Docker-based deployment for comprehensive AI security evaluation._
 * [OpenPromptInjection](https://github.com/liu00222/Open-Prompt-Injection) - _A benchmark for prompt injection attacks and defenses_
+* [tool-output-mimicry](https://github.com/314-ia/tool-output-mimicry) - _Reference reproducer for the Tool Output Mimicry primitive: bypasses multi-layer agentic AI defenses by impersonating an upstream agent's task summary in a user-controlled field that a downstream agent reads. Validated end-to-end against the OWASP FinBot CTF; companion paper at doi.org/10.5281/zenodo.19794072._
 
 ### AI-Assisted Offensive Security
 * [PentestGPT](https://github.com/GreyDGL/PentestGPT) - _A GPT-empowered penetration testing tool_


### PR DESCRIPTION
## Summary

Adds [`314-ia/tool-output-mimicry`](https://github.com/314-ia/tool-output-mimicry) under **Attack Techniques & Red Teaming → Agentic AI & MCP Attack Tools**, next to `mcp-injection-experiments` (the closest conceptual analog: a focused reproducer for a specific multi-agent attack class).

## What it is

Reference reproducer for the *Tool Output Mimicry* primitive — a multi-agent attack that bypasses layered defenses by impersonating an upstream agent's task summary in a user-controllable field that a downstream agent reads. Companion paper:

> Brana, J. P. (2026). *Tool Output Mimicry: Bypassing Multi-Layer Agentic AI Defenses via Upstream-Agent Impersonation in User-Controlled Fields.* Zenodo. [doi:10.5281/zenodo.19794072](https://doi.org/10.5281/zenodo.19794072) (CC BY 4.0).

## Why this section

The threat model is multi-agent specifically (orchestrator → upstream agent → downstream agent), and the empirical capture relies on the orchestrator's task-summary forwarding pattern that the section's existing entries also exercise. It complements `mcp-injection-experiments` (MCP tool-poisoning) and `OpenPromptInjection` (prompt-injection benchmark) by adding a novel primitive at the inter-agent trust boundary.

## What ships

- Reference Python implementation of the primitive
- End-to-end FinBot CTF reproducer with `--dry-run` smoke path
- 24 unit tests passing on Python 3.10–3.13 (CI matrix green)
- Verbatim live-capture transcript (re-validated 2026-04-27)
- Two Zenodo DOIs (paper + software) and a Software Heritage SWHID

## Style compliance

One-line entry, italic underscored description, `* [name](url) - _desc_` format matching the section's existing convention.