### PR TITLE
Add pentest-ai-agents to Agentic AI Security Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [Anthropic Cybersecurity Skills](https://github.com/mukul975/Anthropic-Cybersecurity-Skills) - _734+ structured cybersecurity skills for AI agents. MITRE ATT&CK mapped, agentskills.io standard. Compatible with Claude Code, Copilot, Codex CLI, Cursor, and Gemini CLI._
 * [llm-sast-scanner](https://github.com/SunWeb3Sec/llm-sast-scanner) - _SAST skill for AI coding agents (Claude Code, Codex, etc.) with structured vulnerability detection across 34 classes. Features source-to-sink taint analysis, Judge verification for false positive reduction, and 99%+ precision/recall on benchmarks._
 * [sast-skills](https://github.com/utkusen/sast-skills) - _Collection of agent skills that turn your AI coder into a SAST scanner_
+* [pentest-ai-agents](https://github.com/0xSteph/pentest-ai-agents) - _31 Claude Code subagents for offensive security. Specialized AI subagents for recon, web, AD, cloud, mobile, wireless, social engineering, payload crafting, reverse engineering, exploit chaining, detection engineering, forensics, and report generation. Tier 2 agents can execute tools directly with approval gates._
+* [pentest-ai-agents](https://github.com/0xSteph/pentest-ai-agents) - _31 Claude Code subagents for offensive security. Specialized AI subagents for recon, web, AD, cloud, mobile, wireless, social engineering, payload crafting, reverse engineering, exploit chaining, detection engineering, forensics, and report generation. Tier 2 agents can execute tools directly with approval gates._
 
 ## Security-Focused AI Models
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,6 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [llm-sast-scanner](https://github.com/SunWeb3Sec/llm-sast-scanner) - _SAST skill for AI coding agents (Claude Code, Codex, etc.) with structured vulnerability detection across 34 classes. Features source-to-sink taint analysis, Judge verification for false positive reduction, and 99%+ precision/recall on benchmarks._
 * [sast-skills](https://github.com/utkusen/sast-skills) - _Collection of agent skills that turn your AI coder into a SAST scanner_
 * [pentest-ai-agents](https://github.com/0xSteph/pentest-ai-agents) - _31 Claude Code subagents for offensive security. Specialized AI subagents for recon, web, AD, cloud, mobile, wireless, social engineering, payload crafting, reverse engineering, exploit chaining, detection engineering, forensics, and report generation. Tier 2 agents can execute tools directly with approval gates._
-* [pentest-ai-agents](https://github.com/0xSteph/pentest-ai-agents) - _31 Claude Code subagents for offensive security. Specialized AI subagents for recon, web, AD, cloud, mobile, wireless, social engineering, payload crafting, reverse engineering, exploit chaining, detection engineering, forensics, and report generation. Tier 2 agents can execute tools directly with approval gates._
 
 ## Security-Focused AI Models
 


### PR DESCRIPTION
Adds [pentest-ai-agents](https://github.com/0xSteph/pentest-ai-agents) to the Agentic AI Security Skills section.

**What it is:**
Collection of 31 Claude Code subagents that turn Claude into an offensive security research assistant.

**Key features:**
- 31 specialized subagents for recon, web, AD, cloud, mobile, wireless, social engineering
- Payload crafting, reverse engineering, exploit chaining, detection engineering
- Tier 2 agents can compose and execute commands directly with approval gates
- Slash commands: /recommend and /agents-for for routing
- findings.sh: Persistent SQLite database for engagement data
- db/doctor.sh: Audits installed tools,