### PR TITLE
Add Agent Trust Bench to Benchmarks & Evaluations

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [AICGSecEval](https://github.com/Tencent/AICGSecEval) - _Tencent's comprehensive evaluation benchmark for AI code generation security, covering 10 CWE categories with automated test harness_
 * [Inspect](https://github.com/UKGovernmentBEIS/inspect_ai) - _Framework for large language model evaluations by the UK AI Security Institute. 200+ pre-built evaluations covering prompt engineering, tool usage, multi-turn dialog, and model-graded scoring._
 * [sec-code-bench](https://github.com/alibaba/sec-code-bench) - _Alibaba's benchmark for evaluating LLM code security capabilities across 17 vulnerability categories and 4 programming languages_
+* [Agent Trust Bench](https://agent-trust-bench.algovoi.co.uk) - _166 adversarial and benign x402 payment profiles across 40 threat categories (prompt injection, authority manipulation, identity spoofing, amount mismatch, behavioural pressure). Live test harness for AI agents handling autonomous payment flows -- fake-signing wallet, no real funds. Provider-neutral, works with any x402 facilitator, no account required._
 
 ## Defense & Security Controls
 


### PR DESCRIPTION
## What this adds

**[Agent Trust Bench](https://agent-trust-bench.algovoi.co.uk)** - a live adversarial benchmark specifically for AI agents that handle payment authorisation.

Placed in **Benchmarks & Evaluations**, after AgentDoG (the last entry in that section).

## Why it fits here

Most existing entries in this list test LLMs on static text tasks (code generation, jailbreaks, cyber-offense). Agent Trust Bench is the only published benchmark that tests *agentic payment safety*: the agent is given real payment tools, a fake-signing wallet, and must refuse or complete transactions against 138 adversarial scenarios.

Threat categories covered:

- **Prompt injection / authority spoofing** - malicious strings embedded in payment challenge responses
- **MCP tool injection** - adversarial tool-server descriptions and result fields  
- **Multi-agent orchestration attacks** - delegation laundering, context poisoning, trust chain spoofing
- **Financial manipulation** - fee leg drain, amount mismatch, micro-drift escalation, bait-switch loop
- **Regulatory evasion** - sanctions hop, Travel Rule bypass, velocity structuring

138 scenarios, 30 threat categories, fake-signing wallet (no real funds move). Claude 3.7 Sonnet scored 130/138 (94.2%). Runner and profile definitions are open source.

## Format

Matches the existing `* [name](url) - _description_` style used throughout this section.

---

*AlgoVoi (chopmob-cloud) - chopmob@gmail.com - Acquisition enquiries: https://docs.algovoi.co.uk/acquisition*