### PR TITLE
Add APort to agent runtime security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [Aegis](https://github.com/antropos17/Aegis) - _Open-source EDR for AI agents by Antropos. Monitor processes, files, network, and behavior of autonomous AI agents in real time. No telemetry, no cloud, everything stays local._
 * [Microsoft Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit) - _AI Agent Governance Toolkit from Microsoft — Policy enforcement, zero-trust identity, execution sandboxing, and reliability engineering for autonomous AI agents. Covers 10/10 OWASP Agentic Top 10._
 * [agentfield](https://github.com/Agent-Field/agentfield) - _Open-source control plane for agent systems with cryptographic identity, policy enforcement, and audit-friendly observability._
+* [APort](https://aport.io) - _Agent identity verification and policy enforcement for LLM tool calls, adding pre-action authorization guardrails before agents execute sensitive actions._
 * [leash](https://github.com/strongdm/leash) - _Leash wraps AI coding agents in containers and monitors their activity._
 * [vibekit](https://github.com/superagent-ai/vibekit) - _Run Claude Code, Gemini, Codex — or any coding agent — in a clean, isolated sandbox with sensitive data redaction and observability baked in._
 * [pipelock](https://github.com/luckyPipewrench/pipelock) - _Security harness for AI agents — egress proxy with DLP scanning, SSRF protection, MCP response scanning, and workspace integrity monitoring_


### PR DESCRIPTION
## Problem
APort is missing from this AI security resource list, even though it fits the agent runtime / guardrail category as a tool for agent identity and policy enforcement before sensitive tool calls execute.

## Summary
- Added APort with a one-sentence description.
- Placed it in the existing security/guardrail/runtime tooling section.

## Verification
- Ran git diff --check.
- Verified https://aport.io returns HTTP 200.

## Bounty
Related bounty issue: https://github.com/aporthq/aport-integrations/issues/19

Payment details if this PR qualifies for the bounty:
PayPal: https://paypal.me/Jeremytsangchina
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y