### PR TITLE
Add MCPProxy to MCP Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [MCP Audit VSCode Extension](https://github.com/Agentity-com/mcp-audit-extension) - _Audit and log all GitHub Copilot MCP tool calls in VSCode centrally with ease._
 * [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - _A security scanning tool for MCP servers_
 * [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - _Open-source detection rules for AI agent threats. 108 regex rules covering prompt injection, tool poisoning, credential exfiltration across 9 categories. Used by Cisco AI Defense. MIT licensed._
+* [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) - _Local-first MCP proxy with per-tool SHA-256 quarantine to detect tool-poisoning and rug-pull attacks, automatic sensitive-data and secret scanning of tool calls, Docker sandbox isolation for untrusted MCP servers, and OAuth 2.1. MIT licensed._
 
 ### Model & Artifact Scanning
 * [modelscan](https://github.com/protectai/modelscan) - _ModelScan is an open source project from Protect AI that scans models to determine if they contain unsafe code._


### PR DESCRIPTION
## Add MCPProxy

[MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) is a local-first MCP proxy/gateway built specifically around MCP security concerns:

- **Per-tool SHA-256 quarantine** — detects tool-poisoning and rug-pull attacks by hashing every tool's description and schema; new or changed tools are blocked until manually approved
- **Automatic sensitive-data and secret scanning** — scans all tool call arguments and responses for credentials, API keys, private keys, cloud secrets, and high-entropy strings
- **Docker sandbox isolation** — runs untrusted MCP servers inside isolated containers with no network/FS access to the host
- **OAuth 2.1 with PKCE** — secure authentication for upstream MCP servers

MIT licensed, Go, 229★, 13 contributors, actively maintained (v0.33.1 released 2026).

Website: https://mcpproxy.app