### PR TITLE
Add AiSOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [ThreatForest](https://github.com/aws-samples/sample-agentic-attack-tree-generator) - _Agentic threat modeling platform built on Strands framework. Autonomously generates attack trees from repositories, maps attack steps to MITRE ATT&CK techniques, and produces actionable mitigation recommendations._
 * [claude-grc-plugin](https://github.com/mlunato47/claude-grc-plugin) - _Claude Code plugin that turns Claude into a senior GRC analyst. 72+ reference files covering 15 frameworks (NIST 800-53, FedRAMP, ISO 27001, SOC 2, etc.), 24 slash commands, and deep domain knowledge for federal and commercial compliance work._
 * [Vigil SOC](https://github.com/Vigil-SOC/vigil) - _A comprehensive open-source security operations platform for AI agents, enabling real-time monitoring, threat detection, and incident response for AI-powered environments._
+* [AiSOC](https://github.com/beenuar/AiSOC) - _Open-source, self-hostable AI-powered SOC that ingests security events, correlates them, runs autonomous AI-driven investigations via LangGraph, and surfaces results in a unified console. Features full agent decision audit trail, public eval harness in CI, and 52 first-party connectors. MIT licensed._
 
 ### Privacy & Confidential Computing
 * [Python Differential Privacy Library](https://github.com/OpenMined/PyDP)


### PR DESCRIPTION
Adds [AiSOC](https://github.com/beenuar/AiSOC) to the AI-Assisted Defensive Security section.

AiSOC is an open-source, self-hostable AI-powered SOC with MIT license, 1.1k+ stars, autonomous AI-driven investigations via LangGraph, full agent decision audit trail, public eval harness in CI, and 52 first-party connectors.