### PR TITLE
Add SkilLock under Data & Supply Chain Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [datasig](https://github.com/trailofbits/datasig) - _Dataset fingerprinting for AIBOM_
 * [OWASP AIBOM](https://github.com/OWASP/www-project-aibom) - _AI Bill of Materials_
 * [Trusera ai-bom](https://github.com/Trusera/ai-bom) - _AI Bill of Materials — discover every AI agent, model, and API in your infrastructure_
+* [SkilLock](https://github.com/skills-lock/skil-lock) - _Lockfile + GitHub Action that pins the parsed behavior surface (shell commands, network URLs, file reads/writes) of Claude Code and Codex skills; capability-delta PR review catches drift that hash pinning misses_
 
 ## Agentic AI Security Skills
 


### PR DESCRIPTION
Adds SkilLock under the **Data & Supply Chain Security** subsection of Defense & Security Controls.

SkilLock is an Apache 2.0 Go binary + GitHub Action that parses every SKILL.md in a repo, extracts the capability surface (shell commands, network URLs, file reads/writes, allowed tools, bundled scripts), commits it as `skills.lock`, then runs a capability-delta diff on every PR. The pitch is "package-lock + Dependabot + PR security review, for AI Skills" — adjacent to AIBOM but at PR-time rather than at install-time, and fingerprinting behavior rather than artifact hashes.

Fits Data & Supply Chain Security because the capability surface IS the supply-chain artifact for skills.

Repo: https://github.com/skills-lock/skil-lock
Worked example: https://github.com/skills-lock/example-claude-code-skills