### PR TITLE
Add PromptPurify to Input/Output Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [langkit](https://github.com/whylabs/langkit) - _LangKit is an open-source text metrics toolkit for monitoring language models. The toolkit provides various security related metrics that can be used to detect attacks_
 * [CodeGate](https://codegate.ai) - _An open-source, privacy-focused project that acts as a layer of security within a developer's Code Generation AI workflow_
 * [Future AGI](https://github.com/future-agi/future-agi) - _Open-source self-hostable platform with built-in real-time guardrails for unsafe outputs (jailbreak, PII, injection, toxicity), evals, tracing, simulations, and gateway for LLM and agent applications._
+* [PromptPurify](https://github.com/securelayer7/PROMPTPurify) - _Structural prompt firewall for LLM apps with a trained prompt-injection and jailbreak classifier. Distributed as npm package and Hugging Face model._
 
 ### Agent Runtime Security & Sandboxing
 * [OpenShell](https://github.com/NVIDIA/OpenShell) - _OpenShell is the safe, private runtime for autonomous AI agents. It provides sandboxed execution environments governed by declarative YAML policies that prevent unauthorized file access, data exfiltration, and uncontrolled network activity._


### PR DESCRIPTION
Adds [PromptPurify](https://github.com/securelayer7/PROMPTPurify), an open-source structural prompt firewall for LLM apps. It ships a trained prompt-injection and jailbreak classifier as both an npm package and a Hugging Face model.

Repo: https://github.com/securelayer7/PROMPTPurify
npm: https://www.npmjs.com/package/promptpurify
Hugging Face: https://huggingface.co/Securelayer7/promptpurify