### PR TITLE
Add Aperion Shield to MCP Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - _A security scanning tool for MCP servers_
 * [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - _Open-source detection rules for AI agent threats. 108 regex rules covering prompt injection, tool poisoning, credential exfiltration across 9 categories. Used by Cisco AI Defense. MIT licensed._
 * [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) - _Local-first MCP proxy with per-tool SHA-256 quarantine to detect tool-poisoning and rug-pull attacks, automatic sensitive-data and secret scanning of tool calls, Docker sandbox isolation for untrusted MCP servers, and OAuth 2.1. MIT licensed._
+* [Aperion Shield](https://github.com/AperionAI/shield) - _Local guardrail proxy (single Rust binary) that wraps any MCP server — stdio or Streamable HTTP — and blocks destructive tool calls before they execute. TOFU tool-catalog pinning detects rug pulls; dedicated rule scopes scan tool descriptions for tool poisoning and tool results for prompt injection. 51 starter rules, approval gates, audit logging. Apache-2.0._
 
 ### Model & Artifact Scanning
 * [modelscan](https://github.com/protectai/modelscan) - _ModelScan is an open source project from Protect AI that scans models to determine if they contain unsafe code._


### PR DESCRIPTION
## Summary

Adds [Aperion Shield](https://github.com/AperionAI/shield) to the **MCP Security** section.

Aperion Shield is an open-source (Apache-2.0) local guardrail proxy for AI coding agents (Cursor, Claude Code, Windsurf, etc.). It sits between the agent and any MCP server — stdio or Streamable HTTP — and:

- Blocks destructive tool calls (`DROP TABLE`, `rm -rf`, force-push, unscoped `UPDATE`/`DELETE`) before they execute
- Defends against MCP supply-chain attacks: TOFU tool-catalog pinning detects rug pulls; `tool_description` / `tool_result` rule scopes catch tool poisoning and prompt-injection payloads in tool results
- 51 starter rules, approval gates, audit logging; 280 tests, CI green
- Single Rust binary, runs entirely locally, no cloud dependency

Fits alongside the existing entries in this section (mcp-context-protector, MCPProxy, mcp-guardian) — same threat model, different enforcement approach (policy rules + supply-chain pinning at the proxy seam).