### PR TITLE
Add OpenHack to AI-Assisted Offensive Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [nano-analyzer](https://github.com/weareaisle/nano-analyzer) - _A minimal LLM-powered zero-day vulnerability scanner by AISLE._
 * [clearwing](https://github.com/Lazarus-AI/clearwing) - _Autonomous vulnerability scanner and source-code hunter built on LangGraph._
 * [Zen-AI-Pentest](https://github.com/SHAdd0WTAka/Zen-Ai-Pentest) - _AI-Powered Penetration Testing Framework with automated vulnerability scanning, multi-agent system, and compliance reporting. 72+ security tools, Docker sandbox, ReAct agents, attack path analysis._
+* [OpenHack](https://github.com/openhackai/OpenHack) - _AI-powered multi-agent scanner that autonomously finds SQLi, XSS, IDOR, and auth bypass in your codebase, then verifies each finding through sandbox execution and browser replay. On par with Claude Opus 4.6 at roughly 40x lower cost._
 
 ## Benchmarks & Evaluations
 


### PR DESCRIPTION
Adds [OpenHack](https://github.com/openhackai/OpenHack) under AI-Assisted Offensive Security, alongside peers like strix, shannon, and cai.

OpenHack is an open-source agentic security scanner that exclusively uses open source models. It is 40x cheaper and on par with Claude Opus 4.6. Each finding is verified via sandbox execution and browser replay (so it reports confirmed issues rather than raw alerts).

Thanks for maintaining this list!