### PR TITLE
Add MCP Object-Authz Lab to resources list

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [AI-Red-Teaming-Playground-Labs](https://github.com/microsoft/AI-Red-Teaming-Playground-Labs) - _AI Red Teaming playground labs to run AI Red Teaming trainings including infrastructure._
 * [Damn Vulnerable LLM Agent](https://github.com/ReversecLabs/damn-vulnerable-llm-agent) - _Intentionally vulnerable LLM agent for learning about prompt injection, tool misuse, and agent security_
 * [AI GOAT](https://github.com/dhammon/ai-goat) - _Damn Vulnerable LLM application with 10 challenges covering OWASP LLM Top 10 risks. Educational CTF-style lab._
+* [MCP Object-Authz Lab](https://github.com/WRG-11/mcp-objauthz-lab) - _A vulnerable-by-design MCP server for learning object-level / cross-tenant authorization (BOLA/IDOR) bugs, with a hunt checklist._
 
 ### Podcasts
 * [MLSecOps podcast](https://mlsecops.com/podcast)


### PR DESCRIPTION
Adds the MCP Object-Authz Lab under Courses, Labs & CTFs. It's a vulnerable-by-design MCP server focused on object-level / cross-tenant authorization (BOLA/IDOR) bugs, with a hunt checklist. Fits alongside the existing vulnerable-MCP labs (Damn Vulnerable MCP, vulnerable-mcp-servers-lab).