### PR TITLE
Add DOS Kernel to Agent Runtime Security & Sandboxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [secureclaw](https://github.com/adversa-ai/secureclaw) - _Automated security hardening for OpenClaw AI agents by Adversa AI. 51 audit checks, 12 behavioral rules, 9 scripts, 4 pattern databases. Full OWASP ASI Top 10 coverage. Protects against prompt injection, credential theft, supply chain attacks, and privacy leaks._
 * [defenseclaw](https://github.com/cisco-ai-defense/defenseclaw) - _Enterprise governance layer for OpenClaw from Cisco AI Defense. Scans skills, MCP servers, and plugins with built-in CodeGuard SAST, tool call inspection engine, LLM guardrail proxy, and SIEM integration. Auto-blocks HIGH/CRITICAL findings._
 * [microsandbox](https://github.com/zerocore-ai/microsandbox) - _Lightweight microVM sandbox for running untrusted AI-generated code safely with strong isolation guarantees_
+* [DOS Kernel](https://github.com/anthony-chaudhary/dos-kernel) - _Deterministic trust kernel for AI-agent fleets: verifies "done" claims against git evidence instead of agent self-report, arbitrates concurrent file access between agents, and audits commit messages against their own diffs. No LLM calls; hooks for Claude Code, Cursor, Codex, Gemini CLI plus an MCP server._
 
 ### MCP Security
 * [MCP-Security-Checklist](https://github.com/slowmist/MCP-Security-Checklist) - _A comprehensive security checklist for MCP-based AI tools. Built by SlowMist to safeguard LLM plugin ecosystems._


### PR DESCRIPTION
Adds DOS Kernel — https://github.com/anthony-chaudhary/dos-kernel — to the **Agent Runtime Security & Sandboxing** section.

DOS is a deterministic trust kernel for AI coding agents and agent fleets. It computes verdicts from evidence the agent didn't author: `dos verify` checks that a claimed unit of work actually landed (git ancestry, not self-report), `dos arbitrate` decides whether two concurrent agents may touch the same files, and `dos commit-audit` flags a commit whose message claims work its own diff doesn't contain. MIT-licensed, Python (PyPI: `dos-kernel`), ships an MCP server (`dos-mcp`) and hooks for Claude Code, Cursor, Codex, Gemini CLI, Antigravity, and Claude Cowork.

Placement follows the list's contribution guidelines; link verified.