### PR TITLE
Add Declaw to Agent Runtime Security & Sandboxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [secureclaw](https://github.com/adversa-ai/secureclaw) - _Automated security hardening for OpenClaw AI agents by Adversa AI. 51 audit checks, 12 behavioral rules, 9 scripts, 4 pattern databases. Full OWASP ASI Top 10 coverage. Protects against prompt injection, credential theft, supply chain attacks, and privacy leaks._
 * [defenseclaw](https://github.com/cisco-ai-defense/defenseclaw) - _Enterprise governance layer for OpenClaw from Cisco AI Defense. Scans skills, MCP servers, and plugins with built-in CodeGuard SAST, tool call inspection engine, LLM guardrail proxy, and SIEM integration. Auto-blocks HIGH/CRITICAL findings._
 * [microsandbox](https://github.com/zerocore-ai/microsandbox) - _Lightweight microVM sandbox for running untrusted AI-generated code safely with strong isolation guarantees_
+* [Declaw](https://github.com/declaw-ai) - _Security-first sandboxing platform for AI agents. Firecracker microVM isolation with network policy enforcement (default-deny egress, domain allowlists), PII scanning, prompt injection defense, and audit logging. Apache-2.0 Python/TypeScript/Go SDKs and CLI._
 
 ### MCP Security
 * [MCP-Security-Checklist](https://github.com/slowmist/MCP-Security-Checklist) - _A comprehensive security checklist for MCP-based AI tools. Built by SlowMist to safeguard LLM plugin ecosystems._

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [secureclaw](https://github.com/adversa-ai/secureclaw) - _Automated security hardening for OpenClaw AI agents by Adversa AI. 51 audit checks, 12 behavioral rules, 9 scripts, 4 pattern databases. Full OWASP ASI Top 10 coverage. Protects against prompt injection, credential theft, supply chain attacks, and privacy leaks._
 * [defenseclaw](https://github.com/cisco-ai-defense/defenseclaw) - _Enterprise governance layer for OpenClaw from Cisco AI Defense. Scans skills, MCP servers, and plugins with built-in CodeGuard SAST, tool call inspection engine, LLM guardrail proxy, and SIEM integration. Auto-blocks HIGH/CRITICAL findings._
 * [microsandbox](https://github.com/zerocore-ai/microsandbox) - _Lightweight microVM sandbox for running untrusted AI-generated code safely with strong isolation guarantees_
-* [Declaw](https://github.com/declaw-ai) - _Security-first sandboxing platform for AI agents. Firecracker microVM isolation with network policy enforcement (default-deny egress, domain allowlists), PII scanning, prompt injection defense, and audit logging. Apache-2.0 Python/TypeScript/Go SDKs and CLI._
+* [Declaw](https://github.com/declaw-ai) - _Security-first sandboxing platform for AI agents. Firecracker microVM isolation with per-sandbox network policies (egress filtering, domain allowlists), PII scanning, prompt injection defense, and audit logging. Apache-2.0 Python/TypeScript/Go SDKs and CLI._
 
 ### MCP Security
 * [MCP-Security-Checklist](https://github.com/slowmist/MCP-Security-Checklist) - _A comprehensive security checklist for MCP-based AI tools. Built by SlowMist to safeguard LLM plugin ecosystems._


### PR DESCRIPTION
Adds [Declaw](https://declaw.ai) to the **Agent Runtime Security & Sandboxing** section.

Declaw is a security-first sandboxing platform for AI agents: Firecracker microVM isolation with network policy enforcement (default-deny egress, domain allowlists), PII scanning, prompt injection defense, and audit logging. The Python/TypeScript/Go SDKs and CLI are open source (Apache-2.0) at [github.com/declaw-ai](https://github.com/declaw-ai).

Disclosure: I'm the founder of Declaw.

Thanks for maintaining this list!