### PR TITLE
Add Assay to MCP Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - _A security scanning tool for MCP servers_
 * [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - _Open-source detection rules for AI agent threats. 108 regex rules covering prompt injection, tool poisoning, credential exfiltration across 9 categories. Used by Cisco AI Defense. MIT licensed._
 * [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) - _Local-first MCP proxy with per-tool SHA-256 quarantine to detect tool-poisoning and rug-pull attacks, automatic sensitive-data and secret scanning of tool calls, Docker sandbox isolation for untrusted MCP servers, and OAuth 2.1. MIT licensed._
+* [Assay](https://github.com/Rul1an/assay) - _Policy-as-code for MCP: a fail-closed proxy that denies risky tool calls before they run, emits offline-verifiable evidence bundles of what executed, and enforces IPv4/TCP egress in-kernel via eBPF/LSM and Landlock on Linux. Rust, MIT._
 
 ### Model & Artifact Scanning
 * [modelscan](https://github.com/protectai/modelscan) - _ModelScan is an open source project from Protect AI that scans models to determine if they contain unsafe code._


### PR DESCRIPTION
Adds [Assay](https://github.com/Rul1an/assay) to the MCP Security list, alongside its peers there (mcp-guardian, secure-mcp-gateway, MCPProxy).

Assay is policy-as-code for MCP: a fail-closed proxy that denies risky tool calls before they run, emits offline-verifiable evidence bundles of what actually executed, and enforces IPv4/TCP egress in-kernel via eBPF/LSM and Landlock on Linux. Rust CLI + GitHub Action, MIT.

It's deliberately bounded about what it claims: it's a gate and an evidence layer, not a prompt-injection or tool-poisoning detector and not a trust score. Entry kept to one line in the section's format. Thanks for maintaining the list!