### PR TITLE
Add MCP-Defender

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [secureclaw](https://github.com/adversa-ai/secureclaw) - _Automated security hardening for OpenClaw AI agents by Adversa AI. 51 audit checks, 12 behavioral rules, 9 scripts, 4 pattern databases. Full OWASP ASI Top 10 coverage. Protects against prompt injection, credential theft, supply chain attacks, and privacy leaks._
 * [defenseclaw](https://github.com/cisco-ai-defense/defenseclaw) - _Enterprise governance layer for OpenClaw from Cisco AI Defense. Scans skills, MCP servers, and plugins with built-in CodeGuard SAST, tool call inspection engine, LLM guardrail proxy, and SIEM integration. Auto-blocks HIGH/CRITICAL findings._
 * [microsandbox](https://github.com/zerocore-ai/microsandbox) - _Lightweight microVM sandbox for running untrusted AI-generated code safely with strong isolation guarantees_
+* [MCP-Defender](https://github.com/MCP-Defender/MCP-Defender) - _Runtime defense layer for MCP tool calls — intercepts and validates tool invocations before execution_
 
 ### MCP Security
 * [MCP-Security-Checklist](https://github.com/slowmist/MCP-Security-Checklist) - _A comprehensive security checklist for MCP-based AI tools. Built by SlowMist to safeguard LLM plugin ecosystems._


### PR DESCRIPTION
Adds [MCP-Defender](https://github.com/MCP-Defender/MCP-Defender) to Agent Runtime Security & Sandboxing.

Runtime defense layer for MCP tool calls — intercepts and validates tool invocations before execution