### PR TITLE
Add hego.red (AI/LLM red teaming notes) to Reading & Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [The MLSecOps Top 10 by Institute for Ethical AI & Machine Learning](https://ethical.institute/security.html)
 * [OWASP Multi-Agentic System Threat Modeling](https://genai.owasp.org/resource/multi-agentic-system-threat-modeling-guide-v1-0/)
 * [OWASP: CheatSheet – A Practical Guide for Securely Using Third-Party MCP Servers 1.0](https://genai.owasp.org/resource/cheatsheet-a-practical-guide-for-securely-using-third-party-mcp-servers-1-0/)
+* [hego.red](https://hego.red/) - Practical, hands-on AI/LLM red teaming guide: prompt injection, jailbreaks, indirect injection, RAG poisoning, agent and tool attacks, with a full methodology and worked labs.
 * [hego.red](https://hego.red/) - Practical, hands-on notes on AI/LLM red teaming from zero to hero: prompt injection, jailbreaks, indirect injection, RAG, agent and tool attacks, plus a full methodology and worked labs.
 
 ### Courses, Labs & CTFs

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [The MLSecOps Top 10 by Institute for Ethical AI & Machine Learning](https://ethical.institute/security.html)
 * [OWASP Multi-Agentic System Threat Modeling](https://genai.owasp.org/resource/multi-agentic-system-threat-modeling-guide-v1-0/)
 * [OWASP: CheatSheet – A Practical Guide for Securely Using Third-Party MCP Servers 1.0](https://genai.owasp.org/resource/cheatsheet-a-practical-guide-for-securely-using-third-party-mcp-servers-1-0/)
+* [hego.red](https://hego.red/) - Practical, hands-on notes on AI/LLM red teaming from zero to hero: prompt injection, jailbreaks, indirect injection, RAG, agent and tool attacks, plus a full methodology and worked labs.
 
 ### Courses, Labs & CTFs
 * [Damn Vulnerable MCP Server](https://github.com/harishsg993010/damn-vulnerable-MCP-server) - _A deliberately vulnerable implementation of the Model Context Protocol (MCP) for educational purposes._

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [The MLSecOps Top 10 by Institute for Ethical AI & Machine Learning](https://ethical.institute/security.html)
 * [OWASP Multi-Agentic System Threat Modeling](https://genai.owasp.org/resource/multi-agentic-system-threat-modeling-guide-v1-0/)
 * [OWASP: CheatSheet – A Practical Guide for Securely Using Third-Party MCP Servers 1.0](https://genai.owasp.org/resource/cheatsheet-a-practical-guide-for-securely-using-third-party-mcp-servers-1-0/)
-* [hego.red](https://hego.red/) - Practical, hands-on AI/LLM red teaming guide: prompt injection, jailbreaks, indirect injection, RAG poisoning, agent and tool attacks, with a full methodology and worked labs.
 * [hego.red](https://hego.red/) - Practical, hands-on notes on AI/LLM red teaming from zero to hero: prompt injection, jailbreaks, indirect injection, RAG, agent and tool attacks, plus a full methodology and worked labs.
 
 ### Courses, Labs & CTFs


### PR DESCRIPTION
Adds [hego.red](https://hego.red/), a free, single-page, practical reference for AI/LLM red teaming: prompt injection, jailbreaks, indirect injection, RAG, agent and tool attacks, a methodology mapped to the OWASP LLM Top 10 and MITRE ATLAS, and worked labs. Added to **Learning Resources > Reading & Guides**. No tracking, no signup.