### PR TITLE
Add SkillTotal (static security scanner for AI components)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - _A security scanning tool for MCP servers_
 * [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - _Open-source detection rules for AI agent threats. 108 regex rules covering prompt injection, tool poisoning, credential exfiltration across 9 categories. Used by Cisco AI Defense. MIT licensed._
 * [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) - _Local-first MCP proxy with per-tool SHA-256 quarantine to detect tool-poisoning and rug-pull attacks, automatic sensitive-data and secret scanning of tool calls, Docker sandbox isolation for untrusted MCP servers, and OAuth 2.1. MIT licensed._
+* [SkillTotal](https://github.com/pezhik/skilltotal) - _Free, Apache-2.0 offline static scanner for AI components (agent skills/plugins, MCP servers, npm & PyPI packages, git repos). Deterministic regex + AST (no LLM, no account), evidence-anchored findings for supply-chain risk, dangerous capabilities, prompt-injection surfaces, MCP tool poisoning/shadowing, and data-exfiltration paths; maps to OWASP Agentic Skills Top 10. Outputs JSON and SARIF 2.1.0._
 
 ### Model & Artifact Scanning
 * [modelscan](https://github.com/protectai/modelscan) - _ModelScan is an open source project from Protect AI that scans models to determine if they contain unsafe code._


### PR DESCRIPTION
This adds **SkillTotal** to the **MCP Security** section. SkillTotal is a free, Apache-2.0, offline static security scanner for AI components (agent skills/plugins, MCP servers, npm & PyPI packages, and git repos). Detection is fully deterministic (regex + AST, no LLM and no account), producing evidence-anchored findings for supply-chain risk, dangerous capabilities, prompt-injection surfaces, MCP tool poisoning/shadowing, and data-exfiltration paths, with findings mapped to the OWASP Agentic Skills Top 10 and output as JSON and SARIF 2.1.0.

It fits the MCP Security section as a scanner that statically analyzes MCP server manifests and code for poisoned/shadowed tools and exfiltration paths, complementing the existing MCP scanning and proxy entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)