### PR TITLE
Add h5i to Agent Runtime Security & Sandboxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [secureclaw](https://github.com/adversa-ai/secureclaw) - _Automated security hardening for OpenClaw AI agents by Adversa AI. 51 audit checks, 12 behavioral rules, 9 scripts, 4 pattern databases. Full OWASP ASI Top 10 coverage. Protects against prompt injection, credential theft, supply chain attacks, and privacy leaks._
 * [defenseclaw](https://github.com/cisco-ai-defense/defenseclaw) - _Enterprise governance layer for OpenClaw from Cisco AI Defense. Scans skills, MCP servers, and plugins with built-in CodeGuard SAST, tool call inspection engine, LLM guardrail proxy, and SIEM integration. Auto-blocks HIGH/CRITICAL findings._
 * [microsandbox](https://github.com/zerocore-ai/microsandbox) - _Lightweight microVM sandbox for running untrusted AI-generated code safely with strong isolation guarantees_
+* [h5i](https://github.com/h5i-dev/h5i) - _Rust CLI that runs multiple coding agents (Claude Code, Codex) on the same task, each in its own isolated git-worktree sandbox, has them peer-review each other, then a neutral verifier replays and tests each candidate before merging the one that passes. Every run is versioned in-repo under refs/h5i/* for an auditable trail._
 
 ### MCP Security
 * [MCP-Security-Checklist](https://github.com/slowmist/MCP-Security-Checklist) - _A comprehensive security checklist for MCP-based AI tools. Built by SlowMist to safeguard LLM plugin ecosystems._


### PR DESCRIPTION
This adds [h5i](https://github.com/h5i-dev/h5i) to the **Agent Runtime Security & Sandboxing** section.

h5i is an open-source Rust CLI that runs several coding agents (Claude Code, Codex) on the same task in isolated sandboxes, has them peer-review each other, then a neutral verifier replays and tests each candidate and merges the one that passes. Run metadata is versioned in the repo under refs/h5i/*.

The entry follows the existing format and ordering of the list.