### PR TITLE
Add Agent Prompt Injection Zoo dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,4 +327,5 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [SafetyPrompts](https://safetyprompts.com/) - _Curated collection of safety-relevant prompts for evaluating LLM safety and security properties._
 * [Do-Not-Answer](https://github.com/Libr-AI/do-not-answer) - _Dataset of prompts that responsible LLMs should not answer, for safety evaluation and red teaming._
 * [JailBreakV-28K](https://github.com/SaFoLab-WISC/JailBreakV_28K) - _Large-scale dataset of 28,000 jailbreak prompts for benchmarking LLM safety._
+* [Agent Prompt Injection Zoo](https://github.com/ch040602/agent-prompt-injection-zoo) - _Source-backed archive of agent prompt-injection incidents, sanitized prompt/result examples, trust-boundary patterns, and defensive audit/eval artifacts._
 * [Leaked System Prompts](https://github.com/x1xhlol/system-prompts-and-models-of-ai-tools) - _Collection of leaked system prompts from commercial AI tools — useful for understanding real-world prompt engineering and attack surfaces._


### PR DESCRIPTION
## Summary
- Add Agent Prompt Injection Zoo to the Datasets section
- Position it as a source-backed defensive archive with sanitized prompt/result examples and audit/eval artifacts

## Why
The project collects agent prompt-injection incidents, trust-boundary patterns, and defensive evaluation artifacts, so it fits the AI security dataset/resources scope of this list.