### PR TITLE
Add Adrian to Agent Runtime Security & Sandboxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [secureclaw](https://github.com/adversa-ai/secureclaw) - _Automated security hardening for OpenClaw AI agents by Adversa AI. 51 audit checks, 12 behavioral rules, 9 scripts, 4 pattern databases. Full OWASP ASI Top 10 coverage. Protects against prompt injection, credential theft, supply chain attacks, and privacy leaks._
 * [defenseclaw](https://github.com/cisco-ai-defense/defenseclaw) - _Enterprise governance layer for OpenClaw from Cisco AI Defense. Scans skills, MCP servers, and plugins with built-in CodeGuard SAST, tool call inspection engine, LLM guardrail proxy, and SIEM integration. Auto-blocks HIGH/CRITICAL findings._
 * [microsandbox](https://github.com/zerocore-ai/microsandbox) - _Lightweight microVM sandbox for running untrusted AI-generated code safely with strong isolation guarantees_
+* [Adrian](https://github.com/secureagentics/Adrian) - _Open-source, AARM-aligned runtime security monitoring and control engine for AI agents by Secure Agentics. Analyses agent activity logs (tool calls, actions, outputs) and reasoning traces to detect malicious, misaligned, or out-of-remit behaviour, with optional in-flight intervention (audit vs block mode). Python (LangChain/LangGraph) and TypeScript SDKs, fully self-hostable offline. Apache-2.0._
 
 ### MCP Security
 * [MCP-Security-Checklist](https://github.com/slowmist/MCP-Security-Checklist) - _A comprehensive security checklist for MCP-based AI tools. Built by SlowMist to safeguard LLM plugin ecosystems._


### PR DESCRIPTION
Adds **Adrian** to *Defense & Security Controls → Agent Runtime Security & Sandboxing*.

Adrian is an open-source, [AARM-aligned](https://aarm.dev) runtime security monitoring and control engine for AI agents. It analyses agent activity logs (tool calls, actions, outputs) and reasoning traces to detect malicious, misaligned, or out-of-remit behaviour, and can optionally intervene in-flight (audit vs block mode). Ships Python (LangChain/LangGraph) and TypeScript SDKs, fully self-hostable offline. Apache-2.0.

- Repo: https://github.com/secureagentics/Adrian
- Fits alongside existing entries like Aegis and agentfield (runtime monitoring/control rather than pure sandboxing); placed at the end of the section per its append order.

**Disclosure:** I'm a maintainer of Adrian (Secure Agentics). Happy to adjust wording, placement, or trim the description to house style.