### PR TITLE
Add ATLAS Knowledge Base Agent as sub-bullet under MITRE ATLAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 
 ### Taxonomies, Terminology & Risk Databases
 * [NIST AI 100-2e2023](https://csrc.nist.gov/publications/detail/white-paper/2023/03/08/adversarial-machine-learning-taxonomy-and-terminology/draft) - _Adversarial machine learning taxonomy and terminology_
-* [MITRE ATLAS](https://atlas.mitre.org/)
+* [MITRE ATLAS](https://atlas.mitre.org/) - [ATLAS Knowledge Base Agent](https://github.com/mitre-atlas/atlas-knowledge-base-agent) - _Open-source AI assistant for exploring the ATLAS knowledge base with natural language, MCP server access, and customizable agent workflows._
 * [AVIDML](https://avidml.org/taxonomy/)
 * [MIT AI Risk Repository](https://airisk.mit.edu/)
 * [AI Incident Database](https://incidentdatabase.ai/)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 
 ### Taxonomies, Terminology & Risk Databases
 * [NIST AI 100-2e2023](https://csrc.nist.gov/publications/detail/white-paper/2023/03/08/adversarial-machine-learning-taxonomy-and-terminology/draft) - _Adversarial machine learning taxonomy and terminology_
-* [MITRE ATLAS](https://atlas.mitre.org/) - [ATLAS Knowledge Base Agent](https://github.com/mitre-atlas/atlas-knowledge-base-agent) - _Open-source AI assistant for exploring the ATLAS knowledge base with natural language, MCP server access, and customizable agent workflows._
+* [MITRE ATLAS](https://atlas.mitre.org/)
+  * [ATLAS Knowledge Base Agent](https://github.com/mitre-atlas/atlas-knowledge-base-agent) - _Open-source AI assistant for exploring the ATLAS knowledge base with natural language, MCP server access, and customizable agent workflows._
 * [AVIDML](https://avidml.org/taxonomy/)
 * [MIT AI Risk Repository](https://airisk.mit.edu/)
 * [AI Incident Database](https://incidentdatabase.ai/)


### PR DESCRIPTION
Adds the [ATLAS Knowledge Base Agent](https://github.com/mitre-atlas/atlas-knowledge-base-agent) — an open-source AI assistant for exploring the MITRE ATLAS knowledge base — as a sub-bullet under the existing MITRE ATLAS entry in Taxonomies, Terminology & Risk Databases.

The agent provides natural-language Q&A, MCP server access, and a customizable hierarchical agentic workflow (Langflow-based) for navigating ATLAS tactics, techniques, mitigations, and case studies.