### PR TITLE
Add SecuredAI to security projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [langkit](https://github.com/whylabs/langkit) - _LangKit is an open-source text metrics toolkit for monitoring language models. The toolkit provides various security related metrics that can be used to detect attacks_
 * [CodeGate](https://codegate.ai) - _An open-source, privacy-focused project that acts as a layer of security within a developer's Code Generation AI workflow_
 * [Future AGI](https://github.com/future-agi/future-agi) - _Open-source self-hostable platform with built-in real-time guardrails for unsafe outputs (jailbreak, PII, injection, toxicity), evals, tracing, simulations, and gateway for LLM and agent applications._
+* [SecuredAI](https://securedai.com/) - _Client-side prompt DLP that detects and masks PII/PHI before prompts reach the model (OpenAI/DeepSeek) and restores the originals locally via a zero-knowledge vault._
 
 ### Agent Runtime Security & Sandboxing
 * [OpenShell](https://github.com/NVIDIA/OpenShell) - _OpenShell is the safe, private runtime for autonomous AI agents. It provides sandboxed execution environments governed by declarative YAML policies that prevent unauthorized file access, data exfiltration, and uncontrolled network activity._


### PR DESCRIPTION
Adds **SecuredAI** (https://securedai.com) under *Defense & Security Controls → Input/Output Guardrails*.

It is a client-side prompt DLP layer: detects and masks PII/PHI before prompts reach the model (OpenAI/DeepSeek), then restores originals locally via a zero-knowledge vault. Same category as the existing Safe Zone / LocalMod PII entries; commercial, like Guardrails.ai and Cloaked AI already on the list.

Single-line addition, format matches surrounding entries. Thanks for maintaining the list.