### PR TITLE
Add Google Mantis — agentic AI security review pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [llm-sast-scanner](https://github.com/SunWeb3Sec/llm-sast-scanner) - _SAST skill for AI coding agents (Claude Code, Codex, etc.) with structured vulnerability detection across 34 classes. Features source-to-sink taint analysis, Judge verification for false positive reduction, and 99%+ precision/recall on benchmarks._
 * [sast-skills](https://github.com/utkusen/sast-skills) - _Collection of agent skills that turn your AI coder into a SAST scanner_
 * [pentest-ai-agents](https://github.com/0xSteph/pentest-ai-agents) - _31 Claude Code subagents for offensive security. Specialized AI subagents for recon, web, AD, cloud, mobile, wireless, social engineering, payload crafting, reverse engineering, exploit chaining, detection engineering, forensics, and report generation. Tier 2 agents can execute tools directly with approval gates._
+* [Mantis Skills](https://github.com/google/mantis) - _Google's decoupled, sequential, security-focused pipeline of agentic AI skills for autonomously reviewing, deduplicating, validating, reproducing, and patching vulnerabilities across codebases of any scale. Features a multi-stage pipeline (architecture analysis → threat modeling → research → review → reproduction → patching → calibration → reflection), built-in sandboxing, and a continuous learning loop that adapts across iterative runs. Supports RTL hardware, IaC, ML pipelines, and compiled binaries._
 
 ## Security-Focused AI Models
 


### PR DESCRIPTION
## What

Adds **Google Mantis** (`github.com/google/mantis`) — a pipeline of agentic AI skills for automated vulnerability discovery and remediation.

## Where

Placed under **Agentic AI Security Skills** — the existing section that collects agent skill packages (Trail of Bits, Semgrep, Ghost Security, Elastic). Mantis is explicitly named "Mantis Skills" and is Google's entry in this category.

## Why Mantis fits here

Mantis is a **defensive/security-review framework**, not an attack tool:
- Multi-stage pipeline: architecture analysis → threat modeling → research → review → reproduction → patching → calibration → reflection
- Runs coding agents in isolated sandbox environments
- Built-in sandboxing instructions (`--network none`)
- Continuous learning loop that adapts across iterative runs
- Supports RTL hardware, IaC, ML pipelines, and compiled binaries
- Culminates in **patching**, not just finding

## Alternatives considered

- **AI-Assisted Defensive Security**: Also a good fit (it's a full defensive pipeline). But Mantis's identity as a "skill package" makes the Skills section the more natural home — same reason Trail of Bits and Semgrep skills live there.
- **Attack Techniques**: Rejected — Mantis is explicitly a defensive/QA tool, not an offensive one. Generates PoCs for validation, not for attack.

## Description

The README entry reads:

> Mantis Skills — Google's decoupled, sequential, security-focused pipeline of agentic AI skills for autonomously reviewing, deduplicating, validating, reproducing, and patching vulnerabilities across codebases of any scale. Features a multi-stage pipeline (architecture analysis → threat modeling → research → review → reproduction → patching → calibration → reflection), built-in sandboxing, and a continuous learning loop that adapts across iterative runs. Supports RTL hardware, IaC, ML pipelines, and compiled binaries.