### PR TITLE
Add Guard Bands to Input/Output Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [langkit](https://github.com/whylabs/langkit) - _LangKit is an open-source text metrics toolkit for monitoring language models. The toolkit provides various security related metrics that can be used to detect attacks_
 * [CodeGate](https://codegate.ai) - _An open-source, privacy-focused project that acts as a layer of security within a developer's Code Generation AI workflow_
 * [Future AGI](https://github.com/future-agi/future-agi) - _Open-source self-hostable platform with built-in real-time guardrails for unsafe outputs (jailbreak, PII, injection, toxicity), evals, tracing, simulations, and gateway for LLM and agent applications._
+* [Guard Bands](https://github.com/Cryptix-Security/guard-bands) - _Cryptographic boundaries that separate untrusted content from trusted instructions. Untrusted input is wrapped in HMAC-signed markers and verified server-side before it can reach a tool call — a structural boundary rather than a content classifier; tamper, replay, and expiry fail closed._
 
 ### Agent Runtime Security & Sandboxing
 * [OpenShell](https://github.com/NVIDIA/OpenShell) - _OpenShell is the safe, private runtime for autonomous AI agents. It provides sandboxed execution environments governed by declarative YAML policies that prevent unauthorized file access, data exfiltration, and uncontrolled network activity._


### PR DESCRIPTION
Adds Guard Bands to Defense & Security Controls → Input/Output Guardrails.

A structural, cryptographic input boundary: untrusted content is wrapped in HMAC-signed markers and verified server-side before it can reach a tool call — a boundary control rather than a content classifier. Open-source (MIT), with a wrap/verify/chat API, tests, CI/CodeQL, and a technical paper.

Single-line addition in the repo's format; placed in the best-fit section.