### PR TITLE
Add PrivAiTe to Input/Output Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [ShellWard](https://github.com/jnMetaCode/shellward) - _AI Agent Security Middleware with 8-layer defense against prompt injection, data exfiltration & dangerous commands. Zero dependencies._
 * [CodeGate](https://codegate.ai) - _An open-source, privacy-focused project that acts as a layer of security within a developer's Code Generation AI workflow_
 * [Future AGI](https://github.com/future-agi/future-agi) - _Open-source self-hostable platform with built-in real-time guardrails for unsafe outputs (jailbreak, PII, injection, toxicity), evals, tracing, simulations, and gateway for LLM and agent applications._
+* [PrivAiTe](https://github.com/crp4222/PrivAiTe) - _Self-hosted OpenAI-compatible proxy that reversibly pseudonymizes PII before requests reach the LLM provider, including inside tool-call arguments and multimodal content._
 
 ### Agent Runtime Security & Sandboxing
 * [OpenShell](https://github.com/NVIDIA/OpenShell) - _OpenShell is the safe, private runtime for autonomous AI agents. It provides sandboxed execution environments governed by declarative YAML policies that prevent unauthorized file access, data exfiltration, and uncontrolled network activity._


### PR DESCRIPTION
Adds PrivAiTe, a self-hosted OpenAI-compatible proxy that reversibly pseudonymizes PII before requests reach the provider, including inside tool-call arguments and multimodal content. BSD-3-Clause, actively maintained, ships a reproducible benchmark (https://github.com/crp4222/privaite-bench). Entry follows the section's format and sits at the end of the list like the latest additions.