### PR TITLE
Add CySecBERT

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 ### Domain-Adapted Security Language Models
 
 * [ATTACK-BERT](https://huggingface.co/basel/ATTACK-BERT) - _Sentence-transformer model for mapping security text to MITRE ATT&CK techniques._
+* [CySecBERT](https://huggingface.co/markusbayer/CySecBERT) - _BERT model adapted for cybersecurity and CTI tasks through domain-specific pre-training._
 
 ## Datasets
 


### PR DESCRIPTION
Adds [CySecBERT](https://huggingface.co/markusbayer/CySecBERT) to Domain-Adapted Security Language Models.

BERT model adapted for cybersecurity and CTI tasks through domain-specific pre-training.