### PR TITLE
Add PickySteve to MCP Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - _A security scanning tool for MCP servers_
 * [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - _Open-source detection rules for AI agent threats. 108 regex rules covering prompt injection, tool poisoning, credential exfiltration across 9 categories. Used by Cisco AI Defense. MIT licensed._
 * [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) - _Local-first MCP proxy with per-tool SHA-256 quarantine to detect tool-poisoning and rug-pull attacks, automatic sensitive-data and secret scanning of tool calls, Docker sandbox isolation for untrusted MCP servers, and OAuth 2.1. MIT licensed._
+* [PickySteve](https://github.com/KernelLord/pickysteve) - _MCP stdio server and OpenAI-compatible proxy that routes coding-agent prompts to the right skill via hybrid retrieval and cross-encoder rerank, with an ONNX prompt-injection gate that scans both the raw request and every retrieved document before context assembly. MIT licensed._
 
 ### Model & Artifact Scanning
 * [modelscan](https://github.com/protectai/modelscan) - _ModelScan is an open source project from Protect AI that scans models to determine if they contain unsafe code._


### PR DESCRIPTION
PickySteve is a skill router / context picker for coding agents that runs as an MCP stdio server (or OpenAI-compatible proxy). Its security relevance: every retrieved document — not just the raw request — passes through an ONNX prompt-injection classifier before context assembly, fail-closed, and untrusted content is wrapped in per-call random-nonce boundaries. Red-team results (180-payload corpus, zero bypasses) are documented in the repo's SECURITY_AUDIT.md.

Disclosure: I'm the project author; this PR was prepared by Claude (agent) on my behalf.