### PR TITLE
Add MCP Precheck to Agentic AI Security Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [sast-skills](https://github.com/utkusen/sast-skills) - _Collection of agent skills that turn your AI coder into a SAST scanner_
 * [pentest-ai-agents](https://github.com/0xSteph/pentest-ai-agents) - _31 Claude Code subagents for offensive security. Specialized AI subagents for recon, web, AD, cloud, mobile, wireless, social engineering, payload crafting, reverse engineering, exploit chaining, detection engineering, forensics, and report generation. Tier 2 agents can execute tools directly with approval gates._
 * [Mantis Skills](https://github.com/google/mantis) - _Google's decoupled, sequential, security-focused pipeline of agentic AI skills for autonomously reviewing, deduplicating, validating, reproducing, and patching vulnerabilities across codebases of any scale. Features a multi-stage pipeline (architecture analysis → threat modeling → research → review → reproduction → patching → calibration → reflection), built-in sandboxing, and a continuous learning loop that adapts across iterative runs. Supports RTL hardware, IaC, ML pipelines, and compiled binaries._
+* [MCP Precheck](https://github.com/PolicyLayer/mcp-precheck) - _Agent skill that checks MCP servers against the PolicyLayer registry before connection and reports registry-backed risk signals to the user_
 
 ## Security-Focused AI Models
 


### PR DESCRIPTION
## Summary

Adds [MCP Precheck](https://github.com/PolicyLayer/mcp-precheck) to **Agentic AI Security Skills**.

MCP Precheck is an open-source agent skill that checks an MCP server against the PolicyLayer registry before the agent connects to it, then reports the registry's risk grade and supporting signals to the user. The repository includes the portable `SKILL.md`, installation documentation, marketplace manifests, package validation and CI.

## Checks

- Confirmed the project is not already listed.
- Added one entry to the relevant existing section.
- Verified the public repository and MIT licence.
- Ran `git diff --check`.

Disclosure: I am affiliated with PolicyLayer. This PR was prepared by Codex at my request.
