### PR TITLE
Add Redcells to LLM & GenAI red teaming tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [claude-secure-coding-rules](https://github.com/TikiTribe/claude-secure-coding-rules) - _Open-source security rules that guide Claude Code to generate secure code by default._
 * [DeepTeam](https://github.com/confident-ai/deepteam) - _LLM red teaming framework with 40+ attack methods including prompt injection, jailbreaking, and RAG poisoning. Integrates with CI/CD pipelines._
 
+* [Redcells](https://redcells.net) - _Automated adversarial testing platform for LLMs you own or control. OpenAI-compatible target models, iterative attack→refine layers, dashboard + API._
 ### Agentic AI & MCP Attack Tools
 * [RAMPART](https://github.com/microsoft/RAMPART) - _pytest-native safety and security testing framework for agentic AI applications._
 * [AI-Infra-Guard](https://github.com/Tencent/AI-Infra-Guard/) - _A comprehensive, intelligent, and easy-to-use AI Red Teaming platform developed by Tencent Zhuque Lab. Integrates modules for Infra Scan, MCP Scan, and Jailbreak Evaluation, providing a one-click web UI, REST APIs, and Docker-based deployment for comprehensive AI security evaluation._


### PR DESCRIPTION
Redcells is a public-beta platform for automated adversarial testing of LLMs you own or control.\n\n- OpenAI-compatible target models\n- Structured red-team jobs (prompt injection, jailbreak, data leakage, etc.)\n- Iterative attack→refine pipeline with per-layer prompts, responses, and judge scores\n- Web dashboard + HTTP API for CI/CD integration\n\nWebsite: https://redcells.net | Repo: https://github.com/awdemos/redcell