### PR TITLE
Add emisar to MCP Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - _A security scanning tool for MCP servers_
 * [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - _Open-source detection rules for AI agent threats. 108 regex rules covering prompt injection, tool poisoning, credential exfiltration across 9 categories. Used by Cisco AI Defense. MIT licensed._
 * [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) - _Local-first MCP proxy with per-tool SHA-256 quarantine to detect tool-poisoning and rug-pull attacks, automatic sensitive-data and secret scanning of tool calls, Docker sandbox isolation for untrusted MCP servers, and OAuth 2.1. MIT licensed._
+* [emisar](https://github.com/AndrewDryga/emisar) - _MCP control plane that limits infrastructure agents to defined actions, checks access and policy before dispatch, supports approvals, revalidates requests on the host, and records the outcome._
 
 ### Model & Artifact Scanning
 * [modelscan](https://github.com/protectai/modelscan) - _ModelScan is an open source project from Protect AI that scans models to determine if they contain unsafe code._


### PR DESCRIPTION
## Summary

- add `emisar` to MCP Security
- describe its defined-action boundary, access and policy checks, conditional approvals, host-side validation, and audit record

emisar belongs in this section because its MCP surface is built for infrastructure operations without giving the agent arbitrary shell authority.

## Verification

- confirmed the project repository is reachable
- `git diff --check`
