### PR TITLE
Add agentsurface to MCP Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - _A security scanning tool for MCP servers_
 * [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - _Open-source detection rules for AI agent threats. 108 regex rules covering prompt injection, tool poisoning, credential exfiltration across 9 categories. Used by Cisco AI Defense. MIT licensed._
 * [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) - _Local-first MCP proxy with per-tool SHA-256 quarantine to detect tool-poisoning and rug-pull attacks, automatic sensitive-data and secret scanning of tool calls, Docker sandbox isolation for untrusted MCP servers, and OAuth 2.1. MIT licensed._
+* [agentsurface](https://github.com/Northbeams-Labs/agentsurface) - _Local Go CLI that inventories the AI agent machinery installed on a machine: MCP servers across many clients, desktop extensions, plugins, skills, connectors, scheduled agent tasks, instruction files, and AI browser extensions with their native messaging hosts. Reports what each item declares it can reach. Makes no network calls at all, enforced by a CI check that fails the release. Inventory only: no risk score, no malice judgement, no prompt-injection detection. Apache-2.0._
 
 ### Model & Artifact Scanning
 * [modelscan](https://github.com/protectai/modelscan) - _ModelScan is an open source project from Protect AI that scans models to determine if they contain unsafe code._


### PR DESCRIPTION
Adds agentsurface to the MCP Security section.

A Go CLI that inventories the AI agent machinery installed on a machine. It reads local
configuration and lists MCP servers across many clients, desktop extensions, plugins, skills,
connectors, scheduled agent tasks, instruction files, and AI browser extensions with their
native messaging hosts, then reports what each item declares it can reach.

It is an inventory, not a scanner. It does not judge whether anything it finds is malicious, it
produces no risk score or grade, and it does not detect prompt injection.

It makes no network calls of any kind, needs no account and uploads nothing. That is enforced by
a CI check that fails the release if the binary can reach the network stack.

Apache-2.0, v0.1.0, macOS and Linux. There is no Windows build yet.

Disclosure: I am the author. Happy to move it to Data & Supply Chain Security instead if you
think it sits better next to the AIBOM entries.
