### PR TITLE
Add ContextDuty (Input/Output Guardrails)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [ShellWard](https://github.com/jnMetaCode/shellward) - _AI Agent Security Middleware with 8-layer defense against prompt injection, data exfiltration & dangerous commands. Zero dependencies._
 * [CodeGate](https://codegate.ai) - _An open-source, privacy-focused project that acts as a layer of security within a developer's Code Generation AI workflow_
 * [Future AGI](https://github.com/future-agi/future-agi) - _Open-source self-hostable platform with built-in real-time guardrails for unsafe outputs (jailbreak, PII, injection, toxicity), evals, tracing, simulations, and gateway for LLM and agent applications._
+* [ContextDuty](https://github.com/SHUBHAGYTA24/contextduty) - _Local-first prompt firewall that detects and redacts secrets and PII before they reach AI tools — across the IDE, git, live AI-API traffic, and MCP. Built on Microsoft Presidio. 100% local, MIT._
 
 ### Agent Runtime Security & Sandboxing
 * [OpenShell](https://github.com/NVIDIA/OpenShell) - _OpenShell is the safe, private runtime for autonomous AI agents. It provides sandboxed execution environments governed by declarative YAML policies that prevent unauthorized file access, data exfiltration, and uncontrolled network activity._


### PR DESCRIPTION
Adds [ContextDuty](https://github.com/SHUBHAGYTA24/contextduty) under **Defense & Security Controls → Input/Output Guardrails**.

It's a local-first, MIT-licensed prompt firewall that detects and redacts secrets/PII before they reach AI tools — across the IDE, git, live AI-API traffic, and MCP. Detection is built on Microsoft Presidio + regex detectors; enforcement runs 100% locally. Fits alongside existing entries like Safe Zone and CodeGate.

Live demo: https://huggingface.co/spaces/shubhagyta-24/contextduty