### PR TITLE
Add AVE (Agentic Vulnerability Enumeration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [The Arcanum Prompt Injection Taxonomy](https://arcanum-sec.github.io/arc_pi_taxonomy) - _Comprehensive prompt injection attack classification system covering attack intents, techniques, evasions, and input vectors. Categorizes goals, methods, obfuscation techniques, and attack surfaces for prompt injection attacks._
 * [CSA LLM Threats Taxonomy](https://cloudsecurityalliance.org/artifacts/csa-large-language-model-llm-threats-taxonomy)
 * [OWASP AI Vulnerability Scoring System (AIVSS)](https://github.com/OWASP/www-project-artificial-intelligence-vulnerability-scoring-system) - _Scoring system for AI-specific vulnerabilities, extending CVSS concepts to AI risk dimensions._
+* [AVE (Agentic Vulnerability Enumeration)](https://github.com/aveproject/ave) - _Open standard assigning stable IDs to behavioral vulnerability classes in agentic AI components (MCP servers, agent skills, LLM plugins), scored with OWASP's AIVSS framework._
 
 ### Checklists & Practical Guidance
 * [OWASP LLM Applications Cybersecurity and Governance Checklist](https://genai.owasp.org/resource/llm-applications-cybersecurity-and-governance-checklist-english/)


### PR DESCRIPTION
## Summary

Adds AVE (Agentic Vulnerability Enumeration), an open standard for classifying behavioral vulnerabilities in agentic AI components (MCP servers, agent skills, LLM plugins), scored with OWASP's AIVSS framework.

Placed in **Taxonomies, Terminology & Risk Databases**, directly alongside the existing OWASP AIVSS entry, the scoring framework AVE is built on rather than something invented separately for this.

## Why

The gap this fills: CVE anchors to a package and version, CWE describes a weakness in code, neither has a vocabulary for a behavioral pattern tied to neither, which is what most agentic AI vulnerabilities actually are. AVE is an attempt at that missing layer, stable IDs for distinct behavioral classes, not a competing taxonomy but a layer underneath the frameworks already in this list (crosswalked into MITRE ATLAS and OWASP's MCP Top 10 and Agentic Security Initiative Top 10).

The evidence this holds up outside its own tooling: an independent developer built an unrelated static config auditor, crosswalked his own findings against this taxonomy, and tested it directly against the reference scanner on the same files, no shared code. Most overlapping findings converged on the identical ID, unprompted, a stronger signal than anything self-reported.

Apache 2.0, code and records both. github.com/aveproject/ave.