### PR TITLE
Add OpenSecureAI to Input/Output Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [ShellWard](https://github.com/jnMetaCode/shellward) - _AI Agent Security Middleware with 8-layer defense against prompt injection, data exfiltration & dangerous commands. Zero dependencies._
 * [CodeGate](https://codegate.ai) - _An open-source, privacy-focused project that acts as a layer of security within a developer's Code Generation AI workflow_
 * [Future AGI](https://github.com/future-agi/future-agi) - _Open-source self-hostable platform with built-in real-time guardrails for unsafe outputs (jailbreak, PII, injection, toxicity), evals, tracing, simulations, and gateway for LLM and agent applications._
+* [OpenSecureAI](https://www.opensecureai.com) - _Open-source LLM guardrail (npm `@opensecureai/firewall` + CLI) that decides allow/flag/block over prompt-injection detection and PII/secret redaction, plus a suite of free in-browser AI-security tools._
 
 ### Agent Runtime Security & Sandboxing
 * [OpenShell](https://github.com/NVIDIA/OpenShell) - _OpenShell is the safe, private runtime for autonomous AI agents. It provides sandboxed execution environments governed by declarative YAML policies that prevent unauthorized file access, data exfiltration, and uncontrolled network activity._


### PR DESCRIPTION
Adds **OpenSecureAI** under Defense & Security Controls → Input/Output Guardrails.

Open-source LLM guardrail published on npm (`@opensecureai/firewall`, plus `@opensecureai/scanner`) with a CLI: it decides allow/flag/block over prompt-injection detection and redacts PII/secrets before text reaches a model. Also ships a suite of free in-browser AI-security tools. MIT-licensed. https://www.opensecureai.com

Entry follows the existing `* [Name](url) - _description._` format. Thanks!