### PR TITLE
Add PolicyStrata

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [AgentDoG](https://github.com/AI45Lab/AgentDoG) - _AgentDoG is a risk-aware evaluation and guarding framework for autonomous agents. It focuses on trajectory-level risk assessment, aiming to determine whether an agent's execution trajectory contains safety risks under diverse application scenarios._
 * [AICGSecEval](https://github.com/Tencent/AICGSecEval) - _Tencent's comprehensive evaluation benchmark for AI code generation security, covering 10 CWE categories with automated test harness_
 * [Inspect](https://github.com/UKGovernmentBEIS/inspect_ai) - _Framework for large language model evaluations by the UK AI Security Institute. 200+ pre-built evaluations covering prompt engineering, tool usage, multi-turn dialog, and model-graded scoring._
+* [PolicyStrata](https://github.com/raintree-technology/policystrata) - _Deterministic benchmark and CI scanner for cross-layer policy drift in LLM data agents, with minimized witnesses that identify the first violated responsibility._
 * [sec-code-bench](https://github.com/alibaba/sec-code-bench) - _Alibaba's benchmark for evaluating LLM code security capabilities across 17 vulnerability categories and 4 programming languages_
 
 ## Defense & Security Controls


### PR DESCRIPTION
## Summary

- add [PolicyStrata](https://github.com/raintree-technology/policystrata) to Benchmarks & Evaluations
- describe it as a deterministic benchmark and CI scanner for policy drift

## Why

PolicyStrata is an MIT-licensed, local-first project for deterministic policy regression testing in LLM data-agent stacks. It checks policy responsibilities across model-visible tools, semantic validation, SQL compilation, database controls, and result release.

I maintain PolicyStrata and am disclosing that relationship with this submission.

## Checks

- `git diff --check`
- verified the repository link and entry format