### PR TITLE
Add Jackpot, a browser lab for the OWASP LLM Top 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [AI-Red-Teaming-Playground-Labs](https://github.com/microsoft/AI-Red-Teaming-Playground-Labs) - _AI Red Teaming playground labs to run AI Red Teaming trainings including infrastructure._
 * [Damn Vulnerable LLM Agent](https://github.com/ReversecLabs/damn-vulnerable-llm-agent) - _Intentionally vulnerable LLM agent for learning about prompt injection, tool misuse, and agent security_
 * * [LLMVault](https://github.com/CyberSunil/LLMVault) - _An open-source CTF-style LLM security lab for learning the OWASP LLM Top 10 through hands-on vulnerable exercises covering prompt injection, RAG attacks, system prompt leakage, tool misuse, and agent security._
+* [Jackpot](https://hego.red/jackpot) - _A ten floor casino where every floor is a deliberately broken AI character, one per category of the OWASP Top 10 for LLM Applications, covering prompt injection, system prompt leakage, RAG poisoning, excessive agency and tool abuse. Runs in the browser with no signup._
 
 ### Podcasts
 * [MLSecOps podcast](https://mlsecops.com/podcast)


### PR DESCRIPTION
Adds **Jackpot** (https://hego.red/jackpot), a free browser based lab where each of ten floors is a deliberately vulnerable AI character mapped to one category of the OWASP Top 10 for LLM Applications.

- No signup, no accounts, nothing stored server side
- Ten floors, LLM01 through LLM10: prompt injection, system prompt leakage, RAG poisoning, excessive agency, improper output handling and the rest
- The characters are a deterministic simulation rather than a live model, so it is free to run, needs no API key and grades identically for everyone
- Win conditions, trigger lists and the secrets live server side only, so the answers are not in the page
- Every floor wins on a fact (the secret left the model, the tool fired), never on a guess about intent

One line added, in the format the surrounding entries use.

Disclosure: I am the author.
