### PR TITLE
Add emem-guard to Input/Output Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [CodeGate](https://codegate.ai) - _An open-source, privacy-focused project that acts as a layer of security within a developer's Code Generation AI workflow_
 * [Future AGI](https://github.com/future-agi/future-agi) - _Open-source self-hostable platform with built-in real-time guardrails for unsafe outputs (jailbreak, PII, injection, toxicity), evals, tracing, simulations, and gateway for LLM and agent applications._
 * [Prompt Injection Defenses](https://github.com/tldrsec/prompt-injection-defenses) - _Comprehensive collection of every practical and proposed defense against prompt injection._
+* [emem-guard](https://github.com/Vortx-AI/emem/tree/main/crates/emem-guard) - allow/deny verdict server for claims about the physical world; every verdict is ed25519-signed and hash-chained into an offline-auditable log, and one engine answers Anthropic Inference hooks, Claude Code hooks, MCP tools/call, OpenAI-shaped, CloudEvents and OPA-style inputs
 
 ### Agent Runtime Security & Sandboxing
 * [OpenShell](https://github.com/NVIDIA/OpenShell) - _OpenShell is the safe, private runtime for autonomous AI agents. It provides sandboxed execution environments governed by declarative YAML policies that prevent unauthorized file access, data exfiltration, and uncontrolled network activity._


### PR DESCRIPTION
Both current entries in this section evaluate the *text* of a message.
`emem-guard` evaluates whether the observations a message cites still hold: it
re-resolves each `emem:` token and denies on a failed signature, on bytes that
changed, or on a value that drifted past a band threshold. No detection engine
holds signed observations of the physical world, so none of them can answer
that question.

The half that makes it a security control rather than a lookup is what happens
after the verdict. Each one is ed25519-signed and appended to a hash-chained
log before it is returned, so `emem-guard --audit` detects an altered or
deleted verdict in a log you did not produce.

Apache-2.0, pure Rust, self-hosted, no account. It is deliberately bad at
content classification and stays that way: third-party detectors load as
modules (`--module`, `--signed-module`, or a sidecar over a unix socket) and
their findings get signed and logged like a native rule. A module declaring
`fast` that exceeds 50 ms three times is demoted and stops being able to block.

Happy to move it to Agent Runtime Security or MCP Security if you would rather
file it there.