### PR TITLE
Add Provael under Attack Techniques, Benchmarks, and Taxonomies

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [The Arcanum Prompt Injection Taxonomy](https://arcanum-sec.github.io/arc_pi_taxonomy) - _Comprehensive prompt injection attack classification system covering attack intents, techniques, evasions, and input vectors. Categorizes goals, methods, obfuscation techniques, and attack surfaces for prompt injection attacks._
 * [CSA LLM Threats Taxonomy](https://cloudsecurityalliance.org/artifacts/csa-large-language-model-llm-threats-taxonomy)
 * [OWASP AI Vulnerability Scoring System (AIVSS)](https://github.com/OWASP/www-project-artificial-intelligence-vulnerability-scoring-system) - _Scoring system for AI-specific vulnerabilities, extending CVSS concepts to AI risk dimensions._
+  * [Embodied AI Security Top 10](https://github.com/provael/provael/blob/main/docs/top10.md) - _Versioned community-draft risk list for embodied / VLA robot policies, CC BY-SA 4.0. Explicitly not affiliated with OWASP or MITRE._
 
 ### Checklists & Practical Guidance
 * [OWASP LLM Applications Cybersecurity and Governance Checklist](https://genai.owasp.org/resource/llm-applications-cybersecurity-and-governance-checklist-english/)
@@ -151,6 +152,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [P4RS3LT0NGV3](https://github.com/elder-plinius/P4RS3LT0NGV3) - _Universal text transformation and promptcrafting toolkit. Supports translation, mutation, encoding/decoding, and adversarial prompt engineering for jailbreak payload construction._
 * [claude-secure-coding-rules](https://github.com/TikiTribe/claude-secure-coding-rules) - _Open-source security rules that guide Claude Code to generate secure code by default._
 * [DeepTeam](https://github.com/confident-ai/deepteam) - _LLM red teaming framework with 40+ attack methods including prompt injection, jailbreaking, and RAG poisoning. Integrates with CI/CD pipelines._
+  * [Provael](https://github.com/provael/provael) - _Red-teams vision-language-action robot policies in simulation; emits SARIF tagged with Embodied AI Top 10 rule ids, plus OSCAL and a CycloneDX ML-BOM. Ships as a GitHub Action that fails the build on an ASR regression._
 
 ### Agentic AI & MCP Attack Tools
 * [RAMPART](https://github.com/microsoft/RAMPART) - _pytest-native safety and security testing framework for agentic AI applications._
@@ -197,6 +199,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [AICGSecEval](https://github.com/Tencent/AICGSecEval) - _Tencent's comprehensive evaluation benchmark for AI code generation security, covering 10 CWE categories with automated test harness_
 * [Inspect](https://github.com/UKGovernmentBEIS/inspect_ai) - _Framework for large language model evaluations by the UK AI Security Institute. 200+ pre-built evaluations covering prompt engineering, tool usage, multi-turn dialog, and model-graded scoring._
 * [sec-code-bench](https://github.com/alibaba/sec-code-bench) - _Alibaba's benchmark for evaluating LLM code security capabilities across 17 vulnerability categories and 4 programming languages_
+  * [Provael](https://github.com/provael/provael) - _Red-team harness for robot vision-language-action (VLA) policies. Runs a policy x suite x attack matrix in simulation and reports an attack-success rate with a 95% Wilson interval and a matched benign-instruction control. Apache-2.0._
 
 ## Defense & Security Controls
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [The Arcanum Prompt Injection Taxonomy](https://arcanum-sec.github.io/arc_pi_taxonomy) - _Comprehensive prompt injection attack classification system covering attack intents, techniques, evasions, and input vectors. Categorizes goals, methods, obfuscation techniques, and attack surfaces for prompt injection attacks._
 * [CSA LLM Threats Taxonomy](https://cloudsecurityalliance.org/artifacts/csa-large-language-model-llm-threats-taxonomy)
 * [OWASP AI Vulnerability Scoring System (AIVSS)](https://github.com/OWASP/www-project-artificial-intelligence-vulnerability-scoring-system) - _Scoring system for AI-specific vulnerabilities, extending CVSS concepts to AI risk dimensions._
+* [Embodied AI Security Top 10](https://github.com/provael/provael/blob/main/docs/top10.md) - _Versioned community-draft risk list for embodied / VLA robot policies, CC BY-SA 4.0. Explicitly not affiliated with OWASP or MITRE._
 
 ### Checklists & Practical Guidance
 * [OWASP LLM Applications Cybersecurity and Governance Checklist](https://genai.owasp.org/resource/llm-applications-cybersecurity-and-governance-checklist-english/)
@@ -153,6 +154,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [claude-secure-coding-rules](https://github.com/TikiTribe/claude-secure-coding-rules) - _Open-source security rules that guide Claude Code to generate secure code by default._
 * [DeepTeam](https://github.com/confident-ai/deepteam) - _LLM red teaming framework with 40+ attack methods including prompt injection, jailbreaking, and RAG poisoning. Integrates with CI/CD pipelines._
 * [PoisonedRAG](https://github.com/sleeepeer/PoisonedRAG) - _Knowledge Corruption Attacks to Retrieval-Augmented Generation (USENIX Security 2025)._
+* [Provael](https://github.com/provael/provael) - _Red-teams vision-language-action robot policies in simulation; emits SARIF tagged with Embodied AI Top 10 rule ids, plus OSCAL and a CycloneDX ML-BOM. Ships as a GitHub Action that fails the build on an ASR regression._
 
 ### Agentic AI & MCP Attack Tools
 * [RAMPART](https://github.com/microsoft/RAMPART) - _pytest-native safety and security testing framework for agentic AI applications._
@@ -199,6 +201,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [AICGSecEval](https://github.com/Tencent/AICGSecEval) - _Tencent's comprehensive evaluation benchmark for AI code generation security, covering 10 CWE categories with automated test harness_
 * [Inspect](https://github.com/UKGovernmentBEIS/inspect_ai) - _Framework for large language model evaluations by the UK AI Security Institute. 200+ pre-built evaluations covering prompt engineering, tool usage, multi-turn dialog, and model-graded scoring._
 * [sec-code-bench](https://github.com/alibaba/sec-code-bench) - _Alibaba's benchmark for evaluating LLM code security capabilities across 17 vulnerability categories and 4 programming languages_
+* [Provael](https://github.com/provael/provael) - _Red-team harness for robot vision-language-action (VLA) policies. Runs a policy x suite x attack matrix in simulation and reports an attack-success rate with a 95% Wilson interval and a matched benign-instruction control. Apache-2.0._
 
 ## Defense & Security Controls
 


### PR DESCRIPTION
Three additions, all in the existing entry format.

- **Attack Techniques & Red Teaming → LLM & GenAI Red Teaming**: Provael, red-team harness for robot vision-language-action policies, Apache-2.0
- **Benchmarks & Evaluations**: the same, and worth noting this section currently has **nine entries and none of them cover robotics or embodied systems**
- **Taxonomies, Terminology & Risk Databases**: the Embodied AI Security Top 10, a versioned community-draft risk list for VLA policies, explicitly not affiliated with OWASP or MITRE

Happy to trim to one section if three is too much for a single project. **The Benchmarks one is the one I'd keep**, because the embodied gap in that list is real — I checked the nine entries before writing this and they're all LLM/agent/code-security.

A note on scope so the entry isn't oversold: Provael measures in **simulation**. It has one real-model result (SmolVLA × LIBERO) and zero hardware results, and the repo says so on every surface. The benign-control arm and the confidence interval are reported per row, which is the part I'd argue is worth having in a benchmarks list.

Disclosure: I maintain it.