### PR TITLE
Add piighost to Input/Output Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [CodeGate](https://codegate.ai) - _An open-source, privacy-focused project that acts as a layer of security within a developer's Code Generation AI workflow_
 * [Future AGI](https://github.com/future-agi/future-agi) - _Open-source self-hostable platform with built-in real-time guardrails for unsafe outputs (jailbreak, PII, injection, toxicity), evals, tracing, simulations, and gateway for LLM and agent applications._
 * [Prompt Injection Defenses](https://github.com/tldrsec/prompt-injection-defenses) - _Comprehensive collection of every practical and proposed defense against prompt injection._
+* [piighost](https://github.com/Athroniaeth/piighost) - _Anonymizes PII before it reaches the LLM by replacing values with placeholders and restoring them in the reply, so the provider only sees placeholders. Works as LangChain, Pydantic AI or LlamaIndex integrations, or an OpenAI-compatible proxy._
 
 ### Agent Runtime Security & Sandboxing
 * [OpenShell](https://github.com/NVIDIA/OpenShell) - _OpenShell is the safe, private runtime for autonomous AI agents. It provides sandboxed execution environments governed by declarative YAML policies that prevent unauthorized file access, data exfiltration, and uncontrolled network activity._


### PR DESCRIPTION
Adds piighost to Defense & Security Controls > Input/Output Guardrails (next to Safe Zone, which solves the same problem).

piighost anonymizes PII before it reaches the LLM: personal data becomes placeholders like `<<PERSON:1>>`, the model only sees the placeholders, and the real values are restored in the reply. The same value keeps the same placeholder across a conversation and tool calls. It works as a LangChain/LangGraph middleware, Pydantic AI hooks, LlamaIndex, or an OpenAI-compatible proxy. MIT, on PyPI, with docs and examples.

Repo: https://github.com/Athroniaeth/piighost
Docs: https://athroniaeth.github.io/piighost/
