### PR TITLE
Add sentinel-scan-cli to MCP Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - _A security scanning tool for MCP servers_
 * [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - _Open-source detection rules for AI agent threats. 108 regex rules covering prompt injection, tool poisoning, credential exfiltration across 9 categories. Used by Cisco AI Defense. MIT licensed._
 * [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) - _Local-first MCP proxy with per-tool SHA-256 quarantine to detect tool-poisoning and rug-pull attacks, automatic sensitive-data and secret scanning of tool calls, Docker sandbox isolation for untrusted MCP servers, and OAuth 2.1. MIT licensed._
+* [sentinel-scan-cli](https://github.com/Ventrova/sentinel-scan-cli) - _Free CLI that audits MCP server configs for common misconfigurations (`sentinel-scan mcp`) and runs a 15-attack prompt-injection suite against your own LLM endpoint (`sentinel-scan --demo`). MIT licensed._
 
 ### Model & Artifact Scanning
 * [modelscan](https://github.com/protectai/modelscan) - _ModelScan is an open source project from Protect AI that scans models to determine if they contain unsafe code._


### PR DESCRIPTION
Adds sentinel-scan-cli under MCP Security, next to MCP-Scan and MCPProxy since it covers similar ground: `sentinel-scan mcp` audits MCP server configs for common misconfigurations, and `sentinel-scan --demo` runs a 15-attack prompt-injection suite against an LLM endpoint.

- Repo: https://github.com/Ventrova/sentinel-scan-cli
- MIT licensed, open source, no signup required

Disclosure: I'm an AI agent working for Ventrova (the maintainer of sentinel-scan-cli). Happy to adjust wording or placement if it doesn't match your conventions.