### PR TITLE
Add world-model-mcp under MCP Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - _A security scanning tool for MCP servers_
 * [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - _Open-source detection rules for AI agent threats. 108 regex rules covering prompt injection, tool poisoning, credential exfiltration across 9 categories. Used by Cisco AI Defense. MIT licensed._
 * [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) - _Local-first MCP proxy with per-tool SHA-256 quarantine to detect tool-poisoning and rug-pull attacks, automatic sensitive-data and secret scanning of tool calls, Docker sandbox isolation for untrusted MCP servers, and OAuth 2.1. MIT licensed._
+* [world-model-mcp](https://github.com/SaravananJaichandar/world-model-mcp) - _Signed, offline-verifiable audit chain for MCP client tool calls with portable per-agent identity, key rotation, and delegation. Hybrid Ed25519 + FIPS 205 SLH-DSA-SHA2-128f envelope, Merkle-chained epochs anchored on Sigstore Rekor and Bitcoin OpenTimestamps. Open-source offline reference verifier ships as `etch-verify` inside the same package. MIT licensed._
 
 ### Model & Artifact Scanning
 * [modelscan](https://github.com/protectai/modelscan) - _ModelScan is an open source project from Protect AI that scans models to determine if they contain unsafe code._


### PR DESCRIPTION
Adds `world-model-mcp` to the **MCP Security** section.

### What it is

An MCP-attached signed, offline-verifiable audit chain for AI agent tool calls. Every proxied MCP call becomes a signed row on a hash-chained log. The chain uses a hybrid envelope (classical Ed25519 + post-quantum FIPS 205 SLH-DSA-SHA2-128f), Merkle-hashes rows into epochs, and anchors epoch roots on Sigstore Rekor and Bitcoin OpenTimestamps so third parties can detect operator-side rewrites.

### Fit under MCP Security

The section already covers scanners (`MCP-Scan`), proxies (`MCPProxy`, `secure-mcp-gateway`), guardrails (`mcp-guardian`), and audit tooling (`MCP Audit VSCode Extension`). `world-model-mcp` extends the audit-tooling angle with:

- **Portable per-agent identity** shared across Claude Code, Cursor, Continue, Cline, and Codex, so cross-tool activity resolves to one agent rather than three
- **Key rotation and delegation** as first-class signed records on the chain (grant, revoke, on-behalf-of)
- **Third-party verifiability** via an open-source offline verifier that ships in the same package, so an auditor can verify without vendor cooperation

### Reference implementation

- MIT licensed
- On PyPI as `pip install world-model-mcp` (46+ releases)
- Offline verifier: `etch-verify manifest.json`
- Companion pre-registered SWE-bench Verified benchmark repo with published methodology

Placed after `MCPProxy` at the end of the MCP Security section.