### PR TITLE
Add mcp-scan (npm MCP config security scanner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [mcp-guardian](https://github.com/eqtylab/mcp-guardian/) - _MCP Guardian manages your LLM assistant's access to MCP servers, handing you realtime control of your LLM's activity._
 * [MCP Audit VSCode Extension](https://github.com/Agentity-com/mcp-audit-extension) - _Audit and log all GitHub Copilot MCP tool calls in VSCode centrally with ease._
 * [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - _A security scanning tool for MCP servers_
+* [mcp-scan (npm)](https://github.com/Abanoub-Rodolf/mcp-scan) - _Node CLI that audits local AI tool configs (Claude Desktop, Claude Code, VS Code, Cursor, Windsurf and others) for exposed secrets, prompt injection, supply-chain and permission risks. 16 scanners, SARIF output, MIT. Distinct from the Python MCP-Scan above._
 * [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - _Open-source detection rules for AI agent threats. 108 regex rules covering prompt injection, tool poisoning, credential exfiltration across 9 categories. Used by Cisco AI Defense. MIT licensed._
 * [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) - _Local-first MCP proxy with per-tool SHA-256 quarantine to detect tool-poisoning and rug-pull attacks, automatic sensitive-data and secret scanning of tool calls, Docker sandbox isolation for untrusted MCP servers, and OAuth 2.1. MIT licensed._
 


### PR DESCRIPTION
Adds the npm `mcp-scan` under MCP Security: a Node CLI that audits local AI tool configurations for exposed secrets, prompt injection in tool descriptions, supply-chain and permission risks. 16 scanners, SARIF output, MIT licensed.

Separate project from the `MCP-Scan` already listed directly above it, which is Python and was renamed `snyk-agent-scan` after Snyk acquired Invariant Labs. The entry notes the distinction so the two are not read as duplicates.

- npm: https://www.npmjs.com/package/mcp-scan
- source: https://github.com/Abanoub-Rodolf/mcp-scan