### PR TITLE
Add Lazaretto to MCP Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - _A security scanning tool for MCP servers_
 * [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - _Open-source detection rules for AI agent threats. 108 regex rules covering prompt injection, tool poisoning, credential exfiltration across 9 categories. Used by Cisco AI Defense. MIT licensed._
 * [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) - _Local-first MCP proxy with per-tool SHA-256 quarantine to detect tool-poisoning and rug-pull attacks, automatic sensitive-data and secret scanning of tool calls, Docker sandbox isolation for untrusted MCP servers, and OAuth 2.1. MIT licensed._
+* [Lazaretto](https://github.com/jamesdfinance-dev/lazaretto-mcp) - _Pre-install verification for MCP tools, agent skills and npm packages: matches pinned versions against OSV and OpenSSF malicious-package advisories, then reports credential theft, exfiltration, obfuscation and prompt injection with file-and-line evidence._
 
 ### Model & Artifact Scanning
 * [modelscan](https://github.com/protectai/modelscan) - _ModelScan is an open source project from Protect AI that scans models to determine if they contain unsafe code._


### PR DESCRIPTION
Lazaretto does deterministic pre-install verification for MCP tools, AI agent skills and npm packages. It matches exactly pinned dependencies against OSV and OpenSSF malicious-package advisories, and a paid scan adds behavioral analysis for credential theft, exfiltration, obfuscation, prompt injection and install-time droppers, with file-and-line evidence and a signed attestation that verifies offline.

It fits MCP Security because the use case is inspecting an MCP server or agent skill before it is installed and granted tool access, which complements the entries there that gate or proxy tool calls at runtime. There is no LLM in the scan path, so the same input yields the same verdict.

Anyone can try the free check with no key and no account:
curl -s https://lazaretto.dev/check --data-binary @package-lock.json

Repo: https://github.com/jamesdfinance-dev/lazaretto-mcp
Site: https://lazaretto.dev

Disclosure: I maintain Lazaretto.