### PR TITLE
Add ci-prompt-shield to Input/Output Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [LocalMod](https://github.com/KOKOSde/localmod) - _Self-hosted content moderation API with prompt injection detection, toxicity filtering, PII detection, and NSFW classification. Runs 100% offline._
 * [DynaGuard](https://github.com/montehoover/DynaGuard) - _A Dynamic Guardrail Model With User-Defined Policies_
 * [AprielGuard](https://huggingface.co/blog/ServiceNow-AI/aprielguard) - _8B parameter safety–security safeguard model_
+* [ci-prompt-shield](https://github.com/Rezarys/ci-prompt-shield) - _GitHub Action that sanitizes issue and comment payloads (hidden HTML, zero-width characters, etc.) before they reach a CI code agent such as claude-code-action, mitigating hidden prompt injection._
 * [Safe Zone](https://github.com/thyrisAI/safe-zone) - _Safe Zone is an open-source PII detection and guardrails engine that prevents sensitive data from leaking to LLMs and third-party APIs._
 * [superagent](https://github.com/superagent-ai/superagent) - _Superagent provides purpose-trained guardrails that make AI-agents secure and compliant._
 * [ShellWard](https://github.com/jnMetaCode/shellward) - _AI Agent Security Middleware with 8-layer defense against prompt injection, data exfiltration & dangerous commands. Zero dependencies._


### PR DESCRIPTION
Adds [ci-prompt-shield](https://github.com/Rezarys/ci-prompt-shield), a GitHub Action that sanitizes issue/comment payloads (hidden HTML, zero-width characters, etc.) before they reach a CI code agent (e.g. claude-code-action), to mitigate hidden prompt injection attacks from untrusted GitHub content.