### PR TITLE
Add Aggrete under MCP Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - _A security scanning tool for MCP servers_
 * [ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - _Open-source detection rules for AI agent threats. 108 regex rules covering prompt injection, tool poisoning, credential exfiltration across 9 categories. Used by Cisco AI Defense. MIT licensed._
 * [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) - _Local-first MCP proxy with per-tool SHA-256 quarantine to detect tool-poisoning and rug-pull attacks, automatic sensitive-data and secret scanning of tool calls, Docker sandbox isolation for untrusted MCP servers, and OAuth 2.1. MIT licensed._
+* [Aggrete](https://github.com/Aggrete/aggrete) - _MCP policy proxy that governs what assistants can reach and do: deterministic deny-before-fetch code-of-conduct rules with per-user cross-session accumulation, a prompt-injection egress shield, tool-integrity (rug-pull and poisoning) checks, inbound-secret and output redaction, rate limiting, and a tamper-evident audit. Apache-2.0._
 
 ### Model & Artifact Scanning
 * [modelscan](https://github.com/protectai/modelscan) - _ModelScan is an open source project from Protect AI that scans models to determine if they contain unsafe code._


### PR DESCRIPTION
Adds [Aggrete](https://github.com/Aggrete/aggrete), an open-source MCP policy proxy (Apache-2.0, on PyPI as `aggrete`, GHCR, and listed on Glama).

It enforces a code-of-conduct document across MCP connectors: deterministic deny-before-fetch rules with per-user cross-session accumulation (joins, aggregation, min-group limits), a prompt-injection egress shield, tool-integrity (rug-pull and poisoning) checks, inbound-secret blocking and output redaction, per-user rate limiting, and a tamper-evident hash-chained audit. No model in the decision path.