### PR TITLE
Add source-labeled AI agent incident dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [AVIDML](https://avidml.org/taxonomy/)
 * [MIT AI Risk Repository](https://airisk.mit.edu/)
 * [AI Incident Database](https://incidentdatabase.ai/)
+* [Permission Protocol AI Agent Incident Tracker](https://permissionprotocol.com/agent-incident-tracker/methodology) - _Public-source reports and controlled demonstrations involving AI agents, with evidence-kind labels, source links, overlap notes, methodology and JSON/CSV exports._
 * [ISO/IEC 22989:2022 Information technology — Artificial intelligence — Artificial intelligence concepts and terminology](https://www.iso.org/standard/74296.html)
 * [NIST AI Glossary](https://airc.nist.gov/glossary/)
 * [The Arcanum Prompt Injection Taxonomy](https://arcanum-sec.github.io/arc_pi_taxonomy) - _Comprehensive prompt injection attack classification system covering attack intents, techniques, evasions, and input vectors. Categorizes goals, methods, obfuscation techniques, and attack surfaces for prompt injection attacks._


### PR DESCRIPTION
I maintain this dataset at Permission Protocol. I propose it in the risk-database section because it preserves original source links and separates records labeled realized from controlled demonstrations. The methodology documents collection limits and known overlaps, and keeps our control assessments separate from source facts. The 135 records are not 135 independent production compromises. JSON/CSV downloads and fixed snapshots support checking a citation. Please let me know if the section or resource duplicates an existing entry.
