### PR TITLE
Add DeepZero to AI-assisted offensive security

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [PentAGI](https://github.com/vxcontrol/pentagi) - _Fully autonomous multi-agent system for complex penetration testing tasks. Sandboxed Docker execution, multi-provider LLM support (OpenAI, Anthropic, Gemini, Ollama, DeepSeek), knowledge graph integration, and real-time agent supervision._
 * [V3SP3R](https://github.com/elder-plinius/V3SP3R) - _AI-powered hardware hacking companion for the Flipper Zero. Natural language interface for controlling hardware attacks, with smart glasses integration for hands-free operation._
 
+* [DeepZero](https://github.com/416rehman/DeepZero) - _MIT-licensed Windows driver research framework combining Ghidra decompilation, static analysis, and optional LLM assessment in resumable YAML pipelines._
+
 ### Steganography & Covert Channels
 * [ST3GG](https://github.com/elder-plinius/ST3GG) - _All-in-one steganography suite with multi-layer encoding, image and audio steganography, and steganalysis tools for detecting hidden data in AI-generated media._
 


### PR DESCRIPTION
Adds DeepZero under AI-Assisted Offensive Security. It provides a Windows driver research workflow using Ghidra, static analysis, and optional LLM assessment, with resumable per-sample state.

I maintain the MIT-licensed project. I used it to discover driver vulnerabilities and Claude to reproduce them; the public [Razer Lycosa writeup](https://github.com/416rehman/razer-lycosa-kernel-lpe-BYOVD-Vulnerability-PoC) explicitly credits DeepZero. The listing describes the tool without making autonomous-success or benchmark claims.

Verified the upstream URL, searched issues and PRs for duplicate suggestions, and checked the Markdown diff with `git diff --check`.
