### PR TITLE
Add agent-evidence-vectors to Standards and Verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://mastod
 * [AI Verify](https://github.com/aiverify-foundation/aiverify) - _Singapore government-backed AI testing framework and toolkit for verifying AI system properties against governance frameworks._
 * [Agent Control Standard](https://github.com/GenAI-Security-Project/agent-control-standard) - _Open standard for runtime agent control: declarative hooks, policy enforcement, and observability across AI agent frameworks (OWASP GenAI Security Project)._
 * [AARM](https://aarm.dev) - _Cloud Security Alliance specification defining the system category and capabilities for agentic runtime security._
+* [Agent evidence vectors](https://github.com/astrogilda/agent-evidence-vectors) - _Conformance corpus and reference verifier for the in-toto adversarial-execution-evidence predicate; a verifier is checked by replaying the corpus, and the outcome is recomputed from the bytes an attestation carries rather than read from a producer's verdict._
 
 ### Taxonomies, Terminology & Risk Databases
 * [NIST AI 100-2e2023](https://csrc.nist.gov/publications/detail/white-paper/2023/03/08/adversarial-machine-learning-taxonomy-and-terminology/draft) - _Adversarial machine learning taxonomy and terminology_


### PR DESCRIPTION
One entry in Standards and Verification.

It is a conformance corpus for an in-toto predicate that carries evidence of what an agent did at run time. It ships a reference verifier and the external contract a third-party verifier is driven through. The standards section is where it belongs, because the artifact is the corpus and the rule each vector forces. A verifier written independently of the corpus has replayed it, and the repository records that run and its scope limits.
